### PR TITLE
clarion-setup: auto-install sibling clarion-* skills

### DIFF
--- a/skills/clarion-setup/SKILL.md
+++ b/skills/clarion-setup/SKILL.md
@@ -44,6 +44,7 @@ The script is idempotent. It will:
 - Create the `~/clarion/{data/equities,sec,queue,theses,watchlists,letters}/` data tree
 - Write a default `~/clarion/config.json` (preserves any existing config)
 - Verify the `sec-indexer` console script is on PATH
+- Install every sibling `clarion-*` skill from the repo into `/home/workspace/Skills/` (refreshes any already-installed copies; pass `--skip-skills` to opt out)
 - Print service registration parameters between `--- BEGIN SERVICE_REGISTRATION ---` and `--- END SERVICE_REGISTRATION ---`
 - Print a final `SETUP_RESULT: ok` line on success, or `SETUP_RESULT: error: <reason>` on failure
 
@@ -102,14 +103,9 @@ Tell the user:
 > - Source: `/home/workspace/clarion-intelligence-system/`
 > - Workspace data: `~/clarion/`
 > - Background service: `sec-indexer` (running)
+> - Skills installed under `/home/workspace/Skills/`: every sibling `clarion-*` skill from the repo (regime-check, sec-research, single-stock-eval, expected-return-calc, value-screener, thesis-write, thesis-monitor, watchlist-update, living-letter-update). List the actual names returned in the `[5/6] Installing sibling clarion-* skills ...` block from setup.py.
 >
-> Next, install the skills you want to use. Recommended starter set:
-> - **clarion-regime-check** — SPY/TLT/RSP regime + hurdle rate
-> - **clarion-sec-research** — pull, index, search SEC filings (10-K, 10-Q, Form 3/4/5, 8-K, DEF 14A, etc.)
->
-> Or the full set: `clarion-single-stock-eval`, `clarion-expected-return-calc`, `clarion-value-screener`, `clarion-thesis-write`, `clarion-thesis-monitor`, `clarion-watchlist-update`, `clarion-living-letter-update`.
->
-> Once any of those are installed, just ask me things like *"what's the market regime?"*, *"analyze NVDA's latest 10-K"*, or *"is the market overvalued?"*.
+> Just ask me things like *"what's the market regime?"*, *"analyze NVDA's latest 10-K"*, or *"is the market overvalued?"*.
 
 ## Idempotency
 
@@ -119,6 +115,7 @@ Re-running this skill is safe. Each step:
 - Library install: re-runs `uv pip install -e` (no harm)
 - Data tree: `mkdir -p` (no harm)
 - Config: preserved if present
+- Skill install: each sibling `clarion-*` skill in `/home/workspace/Skills/` is refreshed (overwritten) with the upstream copy. This is the intended path to pull in upstream skill fixes after a `git pull`.
 - Service registration: if the user already has a `sec-indexer` service, `register_user_service` should report it exists; treat that as success.
 
 ### Re-running to pick up source updates

--- a/skills/clarion-setup/scripts/setup.py
+++ b/skills/clarion-setup/scripts/setup.py
@@ -10,8 +10,10 @@ Steps:
 3. mkdir -p ~/clarion/{data/equities,sec,queue,theses,watchlists,letters}
 4. Write ~/clarion/config.json if missing
 5. Verify `sec-indexer` console script resolves
-6. Print service registration envelope for the SKILL.md to consume
-7. Print SETUP_RESULT: ok | error: <reason>
+6. Install sibling clarion-* skills into /home/workspace/Skills/ (unless
+   --skip-skills). Refreshes already-installed skills with the upstream copy.
+7. Print service registration envelope for the SKILL.md to consume
+8. Print SETUP_RESULT: ok | error: <reason>
 
 The SKILL.md parses stdout; structured output goes between
 `--- BEGIN SERVICE_REGISTRATION ---` and `--- END SERVICE_REGISTRATION ---`.
@@ -19,6 +21,7 @@ The SKILL.md parses stdout; structured output goes between
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import shutil
@@ -28,6 +31,9 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]   # skills/clarion-setup/scripts/setup.py → repo
 LIB_DIR = REPO_ROOT / "lib"
+SKILLS_SRC_DIR = REPO_ROOT / "skills"
+SKILLS_INSTALL_DIR = Path("/home/workspace/Skills")
+SETUP_SKILL_NAME = "clarion-setup"  # excluded from auto-install (it's the bootstrap)
 WORKSPACE = Path.home() / "clarion"
 DATA_SUBDIRS = (
     "data/equities",
@@ -145,6 +151,37 @@ def install_library(lib_dir: Path) -> tuple[int, str, str]:
     return result.returncode, result.stdout, result.stderr
 
 
+def install_sibling_skills(
+    src_dir: Path,
+    install_dir: Path,
+    *,
+    exclude: set[str] | None = None,
+) -> list[str]:
+    """Copy each sibling clarion-* skill from src_dir into install_dir.
+
+    Idempotent — already-installed skills are refreshed (overwritten) with
+    the upstream copy. This matches the existing "re-run setup to pull
+    upstream fixes" guidance. The bootstrap skill itself is excluded by
+    default (it's installed externally, before setup runs).
+
+    Returns a list of skill folder names that were installed/refreshed.
+    """
+    exclude = exclude or {SETUP_SKILL_NAME}
+    install_dir.mkdir(parents=True, exist_ok=True)
+    installed: list[str] = []
+    for child in sorted(src_dir.iterdir()):
+        if not child.is_dir() or child.name in exclude:
+            continue
+        if not (child / "SKILL.md").exists():
+            continue
+        dest = install_dir / child.name
+        if dest.exists():
+            shutil.rmtree(dest)
+        shutil.copytree(child, dest)
+        installed.append(child.name)
+    return installed
+
+
 def verify_console_script() -> tuple[int, str]:
     """Confirm `sec-indexer --help` works. Returns (returncode, captured_output)."""
     result = subprocess.run(
@@ -160,6 +197,14 @@ def verify_console_script() -> tuple[int, str]:
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--skip-skills",
+        action="store_true",
+        help="Skip auto-install of sibling clarion-* skills into /home/workspace/Skills/.",
+    )
+    args = parser.parse_args()
+
     print("Clarion Intelligence System — setup\n")
 
     # Step 1 — uv on PATH
@@ -170,20 +215,20 @@ def main() -> None:
     if not LIB_DIR.is_dir():
         fail(f"library directory missing: {LIB_DIR} (is the repo cloned?)")
 
-    print(f"[1/5] Installing ai_buffett_zo from {LIB_DIR} ...")
+    print(f"[1/6] Installing ai_buffett_zo from {LIB_DIR} ...")
     rc, _, stderr = install_library(LIB_DIR)
     if rc != 0:
         fail(f"uv pip install failed (rc={rc}): {stderr.strip()[:300]}")
     print("       installed.")
 
     # Step 3 — data tree
-    print(f"[2/5] Creating data tree under {WORKSPACE} ...")
+    print(f"[2/6] Creating data tree under {WORKSPACE} ...")
     created = make_data_tree(WORKSPACE)
     for d in created:
         print(f"       {d}")
 
     # Step 4 — config
-    print("[3/5] Writing default config ...")
+    print("[3/6] Writing default config ...")
     config_path = write_default_config(WORKSPACE)
     if config_path.read_text().strip() == json.dumps(DEFAULT_CONFIG, indent=2).strip():
         print(f"       wrote {config_path}")
@@ -191,7 +236,7 @@ def main() -> None:
         print(f"       preserved existing {config_path}")
 
     # Step 5 — entrypoint check
-    print("[4/5] Verifying sec-indexer entry point ...")
+    print("[4/6] Verifying sec-indexer entry point ...")
     rc, output = verify_console_script()
     if rc != 0:
         fail(
@@ -201,8 +246,21 @@ def main() -> None:
         )
     print("       OK")
 
-    # Step 6 — registration envelope
-    print("[5/5] Service registration parameters:")
+    # Step 6 — install sibling clarion-* skills
+    if args.skip_skills:
+        print(f"[5/6] Skipping skills auto-install (--skip-skills set).")
+    elif not SKILLS_SRC_DIR.is_dir():
+        print(f"[5/6] Skills source dir missing: {SKILLS_SRC_DIR} — skipping.")
+    else:
+        print(f"[5/6] Installing sibling clarion-* skills into {SKILLS_INSTALL_DIR} ...")
+        installed = install_sibling_skills(SKILLS_SRC_DIR, SKILLS_INSTALL_DIR)
+        for name in installed:
+            print(f"       {name}")
+        if not installed:
+            print("       (none found)")
+
+    # Step 7 — registration envelope
+    print("[6/6] Service registration parameters:")
     print("--- BEGIN SERVICE_REGISTRATION ---")
     print(json.dumps(SERVICE_REGISTRATION_PARAMS, indent=2))
     print("--- END SERVICE_REGISTRATION ---")

--- a/skills/clarion-setup/scripts/setup.py
+++ b/skills/clarion-setup/scripts/setup.py
@@ -28,6 +28,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
+from typing import NoReturn
 
 REPO_ROOT = Path(__file__).resolve().parents[3]   # skills/clarion-setup/scripts/setup.py → repo
 LIB_DIR = REPO_ROOT / "lib"
@@ -105,7 +106,7 @@ Reply with **`done`** in this chat. I'll automatically register the indexer serv
 """
 
 
-def fail(msg: str) -> None:
+def fail(msg: str) -> NoReturn:
     """Emit the error sentinel and exit non-zero."""
     print(f"\nSETUP_RESULT: error: {msg}", flush=True)
     sys.exit(1)
@@ -248,12 +249,16 @@ def main() -> None:
 
     # Step 6 — install sibling clarion-* skills
     if args.skip_skills:
-        print(f"[5/6] Skipping skills auto-install (--skip-skills set).")
+        print("[5/6] Skipping skills auto-install (--skip-skills set).")
     elif not SKILLS_SRC_DIR.is_dir():
         print(f"[5/6] Skills source dir missing: {SKILLS_SRC_DIR} — skipping.")
     else:
         print(f"[5/6] Installing sibling clarion-* skills into {SKILLS_INSTALL_DIR} ...")
-        installed = install_sibling_skills(SKILLS_SRC_DIR, SKILLS_INSTALL_DIR)
+        try:
+            installed = install_sibling_skills(SKILLS_SRC_DIR, SKILLS_INSTALL_DIR)
+        except OSError as e:
+            # Match the rest of main(): structured SETUP_RESULT envelope, not a raw traceback.
+            fail(f"skill install failed: {e}")
         for name in installed:
             print(f"       {name}")
         if not installed:

--- a/tests/test_setup_script.py
+++ b/tests/test_setup_script.py
@@ -155,3 +155,136 @@ def test_user_action_message_constant_is_named_for_discoverability(setup_mod) ->
     assert hasattr(setup_mod, "USER_ACTION_MESSAGE")
     assert isinstance(setup_mod.USER_ACTION_MESSAGE, str)
     assert len(setup_mod.USER_ACTION_MESSAGE) > 200  # not a stub
+
+
+# ---- Sibling-skill auto-install ------------------------------------------
+
+
+def _make_skill(src: Path, name: str) -> Path:
+    """Create a minimal skill folder at src/name with a SKILL.md."""
+    d = src / name
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text(f"---\nname: {name}\n---\n# {name}\n")
+    return d
+
+
+def test_install_sibling_skills_copies_each_skill(setup_mod, tmp_path: Path) -> None:
+    src = tmp_path / "skills_src"
+    src.mkdir()
+    _make_skill(src, "clarion-foo")
+    _make_skill(src, "clarion-bar")
+
+    install_dir = tmp_path / "Skills"
+    installed = setup_mod.install_sibling_skills(src, install_dir)
+
+    assert sorted(installed) == ["clarion-bar", "clarion-foo"]
+    assert (install_dir / "clarion-foo" / "SKILL.md").is_file()
+    assert (install_dir / "clarion-bar" / "SKILL.md").is_file()
+
+
+def test_install_sibling_skills_excludes_bootstrap_by_default(
+    setup_mod, tmp_path: Path
+) -> None:
+    """clarion-setup itself must never be copied — it's installed externally
+    by whatever surfaces the skill in the user's Zo (clone-from-registry, etc.)
+    and the bootstrap copy in /home/workspace/Skills/ is the source of truth
+    for this script's location. Overwriting it from a copy of the same script
+    is at best redundant and at worst a footgun on a partial mid-run."""
+    src = tmp_path / "skills_src"
+    src.mkdir()
+    _make_skill(src, "clarion-setup")
+    _make_skill(src, "clarion-other")
+
+    install_dir = tmp_path / "Skills"
+    installed = setup_mod.install_sibling_skills(src, install_dir)
+
+    assert installed == ["clarion-other"]
+    assert not (install_dir / "clarion-setup").exists()
+
+
+def test_install_sibling_skills_skips_non_skill_dirs(setup_mod, tmp_path: Path) -> None:
+    """A folder without a SKILL.md (e.g. README, shared assets) must not
+    be treated as a skill — guards against future repo additions silently
+    leaking into the user's Skills/ directory."""
+    src = tmp_path / "skills_src"
+    src.mkdir()
+    _make_skill(src, "clarion-good")
+    (src / "_shared").mkdir()
+    (src / "_shared" / "README.md").write_text("not a skill")
+    (src / "stray-file.md").write_text("not a folder")
+
+    install_dir = tmp_path / "Skills"
+    installed = setup_mod.install_sibling_skills(src, install_dir)
+
+    assert installed == ["clarion-good"]
+    assert not (install_dir / "_shared").exists()
+
+
+def test_install_sibling_skills_idempotent_and_refreshes(
+    setup_mod, tmp_path: Path
+) -> None:
+    """Re-running setup must overwrite the installed copy with the upstream
+    one. This is the user-facing path for picking up upstream skill fixes
+    after a `git pull` — same contract as the rest of the setup steps."""
+    src = tmp_path / "skills_src"
+    src.mkdir()
+    skill = _make_skill(src, "clarion-foo")
+    (skill / "scripts").mkdir()
+    (skill / "scripts" / "tool.py").write_text("VERSION = 1\n")
+
+    install_dir = tmp_path / "Skills"
+    setup_mod.install_sibling_skills(src, install_dir)
+    assert (install_dir / "clarion-foo" / "scripts" / "tool.py").read_text() == "VERSION = 1\n"
+
+    # Upstream changes; user simulates a re-run.
+    (skill / "scripts" / "tool.py").write_text("VERSION = 2\n")
+    (skill / "scripts" / "new_file.py").write_text("# added upstream\n")
+    setup_mod.install_sibling_skills(src, install_dir)
+
+    assert (install_dir / "clarion-foo" / "scripts" / "tool.py").read_text() == "VERSION = 2\n"
+    assert (install_dir / "clarion-foo" / "scripts" / "new_file.py").is_file()
+
+
+def test_install_sibling_skills_creates_install_dir_when_missing(
+    setup_mod, tmp_path: Path
+) -> None:
+    src = tmp_path / "skills_src"
+    src.mkdir()
+    _make_skill(src, "clarion-foo")
+
+    install_dir = tmp_path / "nested" / "Skills"
+    assert not install_dir.exists()
+    setup_mod.install_sibling_skills(src, install_dir)
+    assert (install_dir / "clarion-foo" / "SKILL.md").is_file()
+
+
+def test_install_sibling_skills_real_repo_includes_full_stack(
+    setup_mod,
+) -> None:
+    """Regression test for the user-reported gap: setup.py running against
+    the real repo must install every sibling clarion-* skill, not just a
+    subset. If a new clarion-* skill is added to skills/, this test should
+    pass without changes; if a skill is dropped, this test will flag it."""
+    skills_dir = setup_mod.SKILLS_SRC_DIR
+    if not skills_dir.is_dir():
+        pytest.skip(f"skills source dir missing: {skills_dir}")
+
+    siblings = {
+        c.name
+        for c in skills_dir.iterdir()
+        if c.is_dir() and (c / "SKILL.md").is_file() and c.name != "clarion-setup"
+    }
+    # Sanity floor — the repo should always carry at least the named stack.
+    expected_subset = {
+        "clarion-regime-check",
+        "clarion-sec-research",
+        "clarion-single-stock-eval",
+        "clarion-expected-return-calc",
+        "clarion-value-screener",
+        "clarion-thesis-write",
+        "clarion-thesis-monitor",
+        "clarion-watchlist-update",
+        "clarion-living-letter-update",
+    }
+    missing = expected_subset - siblings
+    assert not missing, f"expected sibling skills missing from repo: {missing}"


### PR DESCRIPTION
## Summary

- `setup.py` now copies every sibling `clarion-*` skill from `skills/` into `/home/workspace/Skills/` as a new `[5/6]` step (idempotent — refreshes existing copies). Bootstrap skill itself is excluded.
- `--skip-skills` flag for opt-out.
- SKILL.md updated to document the new step and drop the stale "next, install the skills you want to use" guidance from the success message.
- Six new tests covering the copy, bootstrap-exclusion, non-skill-dir filtering, refresh-on-rerun, install-dir creation, and a regression floor against the real repo (flags if any expected sibling skill ever drops out).

## Motivation

User-reported gap: running `clarion-setup` from a fresh install left the infrastructure up (lib, data tree, sec-indexer) but installed zero user-facing skills. "Set up Clarion" didn't actually set up Clarion — every other `clarion-*` skill had to be installed manually one at a time.

This change makes setup the full one-shot install promised by the skill name.

## Test plan

- [x] `python3.12 -m pytest tests/` → 567 passed (was 561; +6 new tests for the helper)
- [ ] Fresh install dry-run: clone the repo on a clean Zo, run `python skills/clarion-setup/scripts/setup.py`, confirm `/home/workspace/Skills/` ends up populated with all nine sibling skills
- [ ] Re-run on an existing install: confirm the existing `clarion-*` skill folders are refreshed (not left stale) without the user having to delete them first
- [ ] `--skip-skills` opt-out: confirm setup completes without touching `/home/workspace/Skills/`