### PR TITLE
fix: resolve Clarion data root for Zo's /home/workspace layout

### DIFF
--- a/lib/ai_buffett_zo/_paths.py
+++ b/lib/ai_buffett_zo/_paths.py
@@ -1,0 +1,50 @@
+"""Central resolver for the Clarion data root directory.
+
+Why this exists
+---------------
+Several modules need a default path under the user's Clarion workspace.
+Previously each module hardcoded ``Path.home() / "clarion"``. That works on
+a normal user account where $HOME *is* the user-visible workspace, but
+breaks on Zo Computer, where skills run as root (home = /root) while the
+file browser surfaces /home/workspace — making Clarion's theses, letters,
+SEC filings, etc., invisible to the user.
+
+Resolution order
+----------------
+1. ``CLARION_DATA_ROOT`` environment variable. Stripped and ``~``-expanded.
+   Honoured first so users / service-registration can pin an exact path.
+2. ``/home/workspace/clarion`` if ``/home/workspace`` exists. This is the
+   Zo signal — the bootstrap clones the source repo into /home/workspace,
+   so its presence reliably identifies a Zo workspace.
+3. ``Path.home() / "clarion"`` — the original fallback for normal users.
+
+Importantly: the value is captured at module-import time by every consumer
+that builds a ``DEFAULT_*`` constant. For long-running processes (e.g. the
+sec-indexer service), ``CLARION_DATA_ROOT`` must be set BEFORE the process
+starts — setting it in a shell after import has no effect.
+
+Usage
+-----
+::
+
+    from ai_buffett_zo._paths import clarion_home
+
+    DEFAULT_FOO_ROOT = clarion_home() / "foo"
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+ZO_WORKSPACE = Path("/home/workspace")
+
+
+def clarion_home() -> Path:
+    """Return the Clarion data root. See module docstring for resolution order."""
+    env = os.environ.get("CLARION_DATA_ROOT", "").strip()
+    if env:
+        return Path(env).expanduser()
+    if ZO_WORKSPACE.is_dir():
+        return ZO_WORKSPACE / "clarion"
+    return Path.home() / "clarion"

--- a/lib/ai_buffett_zo/data/yfinance_store.py
+++ b/lib/ai_buffett_zo/data/yfinance_store.py
@@ -18,7 +18,9 @@ from dataclasses import dataclass
 from datetime import date, timedelta
 from pathlib import Path
 
-DEFAULT_CACHE_ROOT = Path.home() / "clarion" / "data" / "equities"
+from ai_buffett_zo._paths import clarion_home
+
+DEFAULT_CACHE_ROOT = clarion_home() / "data" / "equities"
 
 
 @dataclass(frozen=True, slots=True)

--- a/lib/ai_buffett_zo/indexer/queue.py
+++ b/lib/ai_buffett_zo/indexer/queue.py
@@ -20,7 +20,9 @@ from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
-DEFAULT_QUEUE_ROOT = Path.home() / "clarion" / "queue"
+from ai_buffett_zo._paths import clarion_home
+
+DEFAULT_QUEUE_ROOT = clarion_home() / "queue"
 
 
 @dataclass

--- a/lib/ai_buffett_zo/letters/io.py
+++ b/lib/ai_buffett_zo/letters/io.py
@@ -16,7 +16,9 @@ import re
 from datetime import date
 from pathlib import Path
 
-DEFAULT_LETTERS_ROOT = Path.home() / "clarion" / "letters"
+from ai_buffett_zo._paths import clarion_home
+
+DEFAULT_LETTERS_ROOT = clarion_home() / "letters"
 
 # Markers that distinguish a populated quarter from a placeholder.
 _POPULATED_MARKERS = (

--- a/lib/ai_buffett_zo/screener/watchlist_io.py
+++ b/lib/ai_buffett_zo/screener/watchlist_io.py
@@ -19,13 +19,14 @@ from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
 
+from ai_buffett_zo._paths import clarion_home
 from ai_buffett_zo.screener.types import (
     ScoredCandidate,
     ScreenContext,
     SectorCapResult,
 )
 
-DEFAULT_WATCHLIST_ROOT = Path.home() / "clarion" / "watchlists"
+DEFAULT_WATCHLIST_ROOT = clarion_home() / "watchlists"
 
 
 # ---- Render ---------------------------------------------------------------

--- a/lib/ai_buffett_zo/secrag/storage.py
+++ b/lib/ai_buffett_zo/secrag/storage.py
@@ -19,10 +19,11 @@ from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import Any
 
+from ai_buffett_zo._paths import clarion_home
 from ai_buffett_zo.secrag.loader import FilingMetadata
 from ai_buffett_zo.secrag.tree import ChunkNode, FilingTree, SectionNode
 
-DEFAULT_SEC_ROOT = Path.home() / "clarion" / "sec"
+DEFAULT_SEC_ROOT = clarion_home() / "sec"
 
 
 def save_raw(root: Path, metadata: FilingMetadata, html: str) -> Path:

--- a/lib/ai_buffett_zo/theses/io.py
+++ b/lib/ai_buffett_zo/theses/io.py
@@ -16,6 +16,7 @@ from collections.abc import Iterable
 from datetime import date
 from pathlib import Path
 
+from ai_buffett_zo._paths import clarion_home
 from ai_buffett_zo.theses.types import (
     HealthComponent,
     HistoryEntry,
@@ -25,7 +26,7 @@ from ai_buffett_zo.theses.types import (
 
 # ---- File system ----------------------------------------------------------
 
-DEFAULT_THESES_ROOT = Path.home() / "clarion" / "theses"
+DEFAULT_THESES_ROOT = clarion_home() / "theses"
 
 
 def list_theses(root: Path = DEFAULT_THESES_ROOT) -> list[Path]:

--- a/skills/clarion-setup/SKILL.md
+++ b/skills/clarion-setup/SKILL.md
@@ -79,10 +79,10 @@ Use the `register_user_service` agent tool with these exact parameters (also pri
 - **mode**: `process`
 - **entrypoint**: `sec-indexer`
 - **workdir**: `/home/workspace`
-- **env_vars**: `{"ZO_API_KEY": "$ZO_API_KEY"}`
+- **env_vars**: copy verbatim from the `SERVICE_REGISTRATION` envelope printed by `setup.py` — includes `ZO_API_KEY` plus a `CLARION_DATA_ROOT` value resolved at setup time (e.g. `/home/workspace/clarion` on Zo)
 - **description**: `Clarion sec-indexer — background SEC EDGAR filing indexer`
 
-The `$ZO_API_KEY` value is shell-style syntax telling Zo to resolve from the user's secret of the same name (created in Step 3) at service start. Use the snake_case parameter names exactly — `workdir` and `env_vars` — these are the canonical keys Zo's tool accepts.
+The `$ZO_API_KEY` value is shell-style syntax telling Zo to resolve from the user's secret of the same name (created in Step 3) at service start. The `CLARION_DATA_ROOT` value is a literal path — it pins the indexer's writes to the same data root chat skills read from, so SEC filings land in the user-visible workspace and not in `/root/clarion/` when the service runs as root. Use the snake_case parameter names exactly — `workdir` and `env_vars` — these are the canonical keys Zo's tool accepts.
 
 Confirm registration succeeded (the tool should return a service ID like `svc_…`).
 
@@ -101,7 +101,7 @@ Tell the user:
 > Clarion is set up.
 >
 > - Source: `/home/workspace/clarion-intelligence-system/`
-> - Workspace data: `~/clarion/`
+> - Workspace data: the path printed in the `[2/6] Creating data tree under …` line from setup.py (typically `/home/workspace/clarion/` on Zo, `~/clarion/` on a local machine — auto-detected)
 > - Background service: `sec-indexer` (running)
 > - Skills installed under `/home/workspace/Skills/`: every sibling `clarion-*` skill from the repo (regime-check, sec-research, single-stock-eval, expected-return-calc, value-screener, thesis-write, thesis-monitor, watchlist-update, living-letter-update). List the actual names returned in the `[5/6] Installing sibling clarion-* skills ...` block from setup.py.
 >

--- a/skills/clarion-setup/scripts/setup.py
+++ b/skills/clarion-setup/scripts/setup.py
@@ -35,7 +35,23 @@ LIB_DIR = REPO_ROOT / "lib"
 SKILLS_SRC_DIR = REPO_ROOT / "skills"
 SKILLS_INSTALL_DIR = Path("/home/workspace/Skills")
 SETUP_SKILL_NAME = "clarion-setup"  # excluded from auto-install (it's the bootstrap)
-WORKSPACE = Path.home() / "clarion"
+
+
+def _clarion_home() -> Path:
+    """Resolve the Clarion data root: env var > Zo auto-detect > $HOME/clarion.
+
+    Inlined here because setup.py runs BEFORE the ai_buffett_zo library is
+    pip-installed. Keep behavior in sync with lib/ai_buffett_zo/_paths.py.
+    """
+    env = os.environ.get("CLARION_DATA_ROOT", "").strip()
+    if env:
+        return Path(env).expanduser()
+    if Path("/home/workspace").is_dir():
+        return Path("/home/workspace/clarion")
+    return Path.home() / "clarion"
+
+
+WORKSPACE = _clarion_home()
 DATA_SUBDIRS = (
     "data/equities",
     "sec",
@@ -58,7 +74,11 @@ SERVICE_REGISTRATION_PARAMS: dict = {
     "mode": "process",
     "entrypoint": "sec-indexer",
     "workdir": "/home/workspace",
-    "env_vars": {"ZO_API_KEY": "$ZO_API_KEY"},
+    # CLARION_DATA_ROOT is pinned to whatever WORKSPACE resolved to at setup
+    # time so the indexer's writes land in the same tree chat skills read from.
+    # Without this the indexer inherits the service-runner's env (e.g. root)
+    # and silently writes to /root/clarion/sec/.
+    "env_vars": {"ZO_API_KEY": "$ZO_API_KEY", "CLARION_DATA_ROOT": str(WORKSPACE)},
     "description": "Clarion sec-indexer — background SEC EDGAR filing indexer",
 }
 

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,59 @@
+"""Tests for lib/ai_buffett_zo/_paths.py — the Clarion data-root resolver."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ai_buffett_zo import _paths
+from ai_buffett_zo._paths import clarion_home
+
+
+def test_env_var_wins(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """CLARION_DATA_ROOT must override both Zo auto-detect and $HOME fallback."""
+    monkeypatch.setenv("CLARION_DATA_ROOT", str(tmp_path / "custom"))
+    monkeypatch.setattr(_paths, "ZO_WORKSPACE", tmp_path / "workspace-exists")
+    (tmp_path / "workspace-exists").mkdir()
+    assert clarion_home() == tmp_path / "custom"
+
+
+def test_env_var_stripped(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Trailing whitespace in the env var must not leak into the path."""
+    monkeypatch.setenv("CLARION_DATA_ROOT", f"  {tmp_path / 'custom'}  ")
+    assert clarion_home() == tmp_path / "custom"
+
+
+def test_env_var_expands_tilde(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A literal ~ in the env var must expand. Common copy/paste footgun."""
+    monkeypatch.setenv("CLARION_DATA_ROOT", "~/clarion-test")
+    assert clarion_home() == Path.home() / "clarion-test"
+
+
+def test_zo_autodetect(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """When the Zo workspace dir exists and no env var, return its clarion/ child."""
+    monkeypatch.delenv("CLARION_DATA_ROOT", raising=False)
+    fake_zo = tmp_path / "zo-workspace"
+    fake_zo.mkdir()
+    monkeypatch.setattr(_paths, "ZO_WORKSPACE", fake_zo)
+    assert clarion_home() == fake_zo / "clarion"
+
+
+def test_home_fallback(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """No env var and no Zo workspace dir → original $HOME/clarion behavior."""
+    monkeypatch.delenv("CLARION_DATA_ROOT", raising=False)
+    monkeypatch.setattr(_paths, "ZO_WORKSPACE", tmp_path / "does-not-exist")
+    assert clarion_home() == Path.home() / "clarion"
+
+
+def test_empty_env_var_treated_as_unset(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An empty/whitespace-only env var must not short-circuit to Path('').
+
+    Guards against a misconfigured service registration that sets the var
+    to an empty string clobbering the auto-detect.
+    """
+    monkeypatch.setenv("CLARION_DATA_ROOT", "   ")
+    monkeypatch.setattr(_paths, "ZO_WORKSPACE", tmp_path / "does-not-exist")
+    assert clarion_home() == Path.home() / "clarion"


### PR DESCRIPTION
## Problem

All `DEFAULT_*` path constants and `setup.py` hardcoded `Path.home() / "clarion"`. On Zo Computer, skills run as **root** so `Path.home()` → `/root`, putting Clarion's theses, letters, watchlists, and SEC filings into `/root/clarion/` — **outside** the user-visible `/home/workspace` file browser. The data was effectively invisible.

## Fix (three-tier resolution)

New `lib/ai_buffett_zo/_paths.py:clarion_home()` resolves with this priority:

1. **`CLARION_DATA_ROOT` env var** — stripped, `~`-expanded. Honoured first so service registration / CI / Docker can pin an exact path.
2. **Zo auto-detect** — if `/home/workspace` exists, return `/home/workspace/clarion`. The bootstrap clones the source repo into `/home/workspace`, so its presence is a reliable Zo signal.
3. **`Path.home() / "clarion"`** — original fallback for normal user accounts.

## End-to-end wiring

The env-var mechanism alone wouldn't have closed the bug — nothing was setting it. This PR wires it through the entire stack:

- **All six `DEFAULT_*_ROOT` constants** in the lib now read `clarion_home()`.
- **`setup.py`** inlines the same resolver (it runs *before* `uv pip install`, so it can't import from the package).
- **`SERVICE_REGISTRATION_PARAMS.env_vars`** now passes `CLARION_DATA_ROOT=<resolved-WORKSPACE>` to the `sec-indexer` service. Without this the indexer process inherits the service-runner's env (root) and silently writes filings to `/root/clarion/sec/` while chat skills read from `/home/workspace/clarion/sec/` — a split-brain that wouldn't show data anywhere.
- **`SKILL.md`** documents the new `env_vars` line and reports the auto-detected data root in the success message.

## Tests

`tests/test_paths.py` (6 new tests, all green; full suite 573/573):

- env var honoured + beats Zo auto-detect
- env var stripped of whitespace
- `~` expansion (common copy-paste footgun)
- Zo auto-detect when env var unset
- `$HOME` fallback when neither env nor `/home/workspace` present
- empty/whitespace-only env var treated as unset (guards a misconfigured service registration from clobbering auto-detect)

## Backwards compatibility

Users with no env var on a non-Zo machine get exactly the original `~/clarion/` behavior. The only behavior change for them: tilde is now expanded in `CLARION_DATA_ROOT` (was a literal `~` before).

## Files

| File | Change |
|------|--------|
| `lib/ai_buffett_zo/_paths.py` | new — 3-tier `clarion_home()` resolver |
| `lib/ai_buffett_zo/{data,indexer,letters,screener,secrag,theses}/...` | 6 modules use `clarion_home()` |
| `skills/clarion-setup/scripts/setup.py` | inline resolver + `CLARION_DATA_ROOT` in service env_vars |
| `skills/clarion-setup/SKILL.md` | document service env_var + auto-detect |
| `tests/test_paths.py` | new — 6 unit tests |