### PR TITLE
clarion-setup: refresh SKILL.md frontmatter description

### DIFF
--- a/skills/clarion-setup/SKILL.md
+++ b/skills/clarion-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clarion-setup
-description: Bootstraps the Clarion Intelligence System on Zo Computer. Run this once after installing the skill — clones the source repo, installs the ai_buffett_zo Python library, creates the ~/clarion/ workspace, writes default config, and registers the sec-indexer background service. Idempotent (safe to re-run). Use when the user asks to "set up Clarion", "install Clarion", or after they install any other clarion-* skill before it has been bootstrapped.
+description: Bootstraps the Clarion Intelligence System on Zo Computer. Run this once after installing — clones the source repo, installs the ai_buffett_zo Python library, creates the workspace data tree under /home/workspace/clarion/ (auto-detected on Zo), auto-installs all nine sibling clarion-* skills (regime-check, sec-research, single-stock-eval, expected-return-calc, value-screener, thesis-write, thesis-monitor, watchlist-update, living-letter-update) under /home/workspace/Skills/, and registers the sec-indexer background service. Idempotent (safe to re-run; refreshes installed skills with upstream copies). This is the only Clarion skill a user needs to install manually — every other clarion-* skill is installed by this one. Use when the user asks to "set up Clarion" or "install Clarion".
 metadata:
   author: cis.zo.computer
   category: External


### PR DESCRIPTION
The frontmatter \`description:\` field hadn't been touched since the original ship and still describes pre-#1 behavior. The body of the doc was already updated by #1 and #2; this brings the frontmatter in line.

## Why this matters

The Zo skill registry's \`manifest.json\` is regenerated from each skill's frontmatter \`description:\` field, not from the doc body. Anything that reads from manifest (registry catalog UI, search, the \`description\` field surfaced to chat agents during skill discovery) is currently advertising the pre-#1 capabilities — no sibling-skill install, no Zo data-root auto-detect, and a now-nonsensical trigger phrase about "after they install any other clarion-* skill before it has been bootstrapped" (the bootstrap installs them all now).

## Diff

Old description (pre-#1, current):

> Bootstraps the Clarion Intelligence System on Zo Computer. Run this once after installing the skill — clones the source repo, installs the ai_buffett_zo Python library, creates the ~/clarion/ workspace, writes default config, and registers the sec-indexer background service. Idempotent (safe to re-run). Use when the user asks to "set up Clarion", "install Clarion", or after they install any other clarion-* skill before it has been bootstrapped.

New description (matches actual current behavior):

> Bootstraps the Clarion Intelligence System on Zo Computer. Run this once after installing — clones the source repo, installs the ai_buffett_zo Python library, creates the workspace data tree under /home/workspace/clarion/ (auto-detected on Zo), auto-installs all nine sibling clarion-* skills (regime-check, sec-research, single-stock-eval, expected-return-calc, value-screener, thesis-write, thesis-monitor, watchlist-update, living-letter-update) under /home/workspace/Skills/, and registers the sec-indexer background service. Idempotent (safe to re-run; refreshes installed skills with upstream copies). This is the only Clarion skill a user needs to install manually — every other clarion-* skill is installed by this one. Use when the user asks to "set up Clarion" or "install Clarion".

## After merge

A sync PR to \`zocomputer/skills\` will follow — that's the change that actually causes \`manifest.json\` to be regenerated on the Zo side (their bot fires on merges into \`External/\`).