### PR TITLE
feat: surface big_blue_day + capitulation daily fire flags on RegimeSnapshot

### DIFF
--- a/docs/PERSONAS-AND-RULES.md
+++ b/docs/PERSONAS-AND-RULES.md
@@ -83,6 +83,15 @@ Your only job is to read, report, and contextualize the cross-asset regime. You 
 
 **Breadth flag** is a separate signal, never a color override: `narrow` when the RSP-SPY 60d spread is ≤ −5%, `broad` otherwise. Surface it for sizing context but do not let it change the color.
 
+**Daily fire flags** (1-bar signals, also separate from color):
+
+| Flag | Trigger | When it fires, surface as |
+|---|---|---|
+| `big_blue_day` | SPY 1d < −1% AND TLT 1d > +1% | "Acute risk-off shock with bonds hedging hard. High-odds add-on-weakness window. 1–2 trading day actionable horizon." |
+| `capitulation` | SPY 1d < −1% AND TLT 1d < 0 AND SPY volume > 1.5× 20d avg | "Both-down panic with above-average participation. Buy-the-panic regime. 1–2 trading day actionable horizon." |
+
+Both flags are backed by a 24-year backtest at `backtests/spy_tlt_signals/` — combined signal at 1-day hold delivers Sharpe 0.65 vs SPY B&H 0.43 with 75% drawdown reduction. The actionable window is 1–2 days; the DD wall sits at 3+ day holds.
+
 Hurdle rate formula: `hurdle = rf + regime_premium`
 Example: ORANGE + rf 4.5% → hurdle = **10.5%**
 
@@ -122,8 +131,9 @@ Good: "Regime: BLUE. Hurdle: 8.5% (rf 4.5% + 4.0% premium). SPY 20d: −2.1%. TL
 2. **Never fabricate numbers.** If yfinance data is unavailable, say so. Suggest `--offline` or a retry. Do not estimate.
 3. **DANGER state overrides everything.** In DANGER, the answer to "should I buy X?" is always: "Regime is DANGER. No new longs. Capital preservation first." Full stop — do not engage with the stock question.
 4. **Breadth is a flag, not a color override.** Surface `narrow leadership` for sizing context, but never escalate or change the color because of it. Color reflects the SPY/TLT quadrant only.
-5. **Don't opine on individual names.** Macro scope only. Route single-stock questions to the Clarion Portfolio Manager or Analyst persona.
-6. **Show the math.** Hurdle rate is always expressed as `rf + premium = hurdle`, never just the number alone.
+5. **Daily fire flags are informational, not commands.** When `big_blue_day` or `capitulation` fires, surface the callout from `regime.py` output verbatim and note the 1–2 day actionable window — but never instruct the user to buy. Operator decides whether to deploy; the system surfaces context.
+6. **Don't opine on individual names.** Macro scope only. Route single-stock questions to the Clarion Portfolio Manager or Analyst persona.
+7. **Show the math.** Hurdle rate is always expressed as `rf + premium = hurdle`, never just the number alone.
 ```
 
 ---

--- a/lib/ai_buffett_zo/regime/color.py
+++ b/lib/ai_buffett_zo/regime/color.py
@@ -1,4 +1,4 @@
-"""SPY/TLT/RSP color regime + equity hurdle rate.
+"""SPY/TLT/RSP color regime + equity hurdle rate + daily fire flags.
 
 Five colors capture the cross-asset risk environment, classified on 20-day
 return signs for SPY and TLT:
@@ -24,6 +24,26 @@ color change. Color reflects the SPY/TLT quadrant only.
 Each color maps to (a) an allocation band per ALLOCATION-POLICY.md and
 (b) an equity hurdle premium added to the risk-free rate. Worse regimes
 demand a higher hurdle — we require more expected return before deploying.
+
+Daily fire flags (1-day return signals, evaluated independently of the
+20-day color):
+
+    big_blue_day    SPY 1d return < -1% AND TLT 1d return > +1%.
+                    Acute risk-off shock where bonds are hedging hard.
+                    Empirical edge backed by backtests/spy_tlt_signals/
+                    (Sharpe 0.65 vs SPY B&H 0.43, full 24yr, with -13.6%
+                    max DD vs B&H -55.2%). 1-2 trading day actionable
+                    window per the backtest's DD-wall finding.
+
+    capitulation    SPY 1d return < -1% AND TLT 1d return < 0 AND SPY
+                    volume > 1.5x its trailing 20d average. Both-down
+                    panic with above-average participation — the
+                    classic "buy the panic" regime for long-horizon
+                    investors. Same 1-2 day actionable window.
+
+Both flags are informational — they identify high-value forward-return
+windows but never override the color or hurdle. Operator decides whether
+to deploy capital on a fire.
 
 Color semantics revised 2026-05-13 to match the SPY/TLT strat framework
 in jingerzz/AI-trading-platform. Historical theses/letters tagged with
@@ -59,6 +79,14 @@ DEFAULT_LOOKBACK_LONG = 60   # ~3 trading months
 DEFAULT_DRAWDOWN_DANGER = -0.20
 DEFAULT_BREADTH_NARROW = -0.05  # RSP - SPY 60d cumulative spread
 
+# Daily fire-flag thresholds (1-day returns + volume).
+# Matched to backtests/spy_tlt_signals/results/2026-05-14_phase2-signals.md.
+BBD_SPY_THRESHOLD = -0.01
+BBD_TLT_THRESHOLD = 0.01
+CAP_SPY_THRESHOLD = -0.01
+CAP_VOL_MULT = 1.5
+CAP_VOL_WINDOW = 20
+
 
 @dataclass(frozen=True)
 class RegimeSnapshot:
@@ -71,6 +99,11 @@ class RegimeSnapshot:
     hurdle_rate_pct: float | None   # None if rf_rate_pct not supplied
     rationale: str                  # which rule fired and why
     breadth_flag: BreadthFlag       # "narrow" if RSP lags SPY by ≥ threshold
+    # Daily (1-bar) signals — default False so existing fixtures don't break.
+    spy_ret_1d: float = 0.0
+    tlt_ret_1d: float = 0.0
+    big_blue_day: bool = False
+    capitulation: bool = False
 
 
 def snapshot(
@@ -103,6 +136,18 @@ def snapshot(
     rsp_vs_spy_long = rsp_ret_long - spy_ret_long
     drawdown = _drawdown_from_high(spy, lookback=252)
 
+    spy_ret_1d = _ret(spy, 1)
+    tlt_ret_1d = _ret(tlt, 1)
+    spy_vol_today = spy[-1].volume
+    spy_vol_avg = _trailing_volume_avg(spy, CAP_VOL_WINDOW)
+    big_blue_day = (spy_ret_1d < BBD_SPY_THRESHOLD) and (tlt_ret_1d > BBD_TLT_THRESHOLD)
+    capitulation = (
+        spy_ret_1d < CAP_SPY_THRESHOLD
+        and tlt_ret_1d < 0
+        and spy_vol_avg is not None
+        and spy_vol_today > CAP_VOL_MULT * spy_vol_avg
+    )
+
     color, rationale = _classify(
         spy_ret_short=spy_ret_short,
         tlt_ret_short=tlt_ret_short,
@@ -130,6 +175,10 @@ def snapshot(
         hurdle_rate_pct=hurdle,
         rationale=rationale,
         breadth_flag=breadth_flag,
+        spy_ret_1d=spy_ret_1d,
+        tlt_ret_1d=tlt_ret_1d,
+        big_blue_day=big_blue_day,
+        capitulation=capitulation,
     )
 
 
@@ -182,6 +231,18 @@ def _ret(bars: Sequence[Bar], lookback: int) -> float:
     end = bars[-1].close
     start = bars[-lookback - 1].close
     return (end / start) - 1.0
+
+
+def _trailing_volume_avg(bars: Sequence[Bar], window: int) -> float | None:
+    """Mean of the prior ``window`` bars' volumes (excluding the most recent).
+
+    Returns None if fewer than ``window`` prior bars are available. The
+    exclusion of the latest bar is deliberate: today's volume is what we
+    compare *against* the trailing average.
+    """
+    if len(bars) < window + 1:
+        return None
+    return float(sum(b.volume for b in bars[-window - 1 : -1])) / window
 
 
 def _drawdown_from_high(bars: Sequence[Bar], *, lookback: int = 252) -> float:

--- a/skills/clarion-regime-check/references/regime-color-guide.md
+++ b/skills/clarion-regime-check/references/regime-color-guide.md
@@ -66,6 +66,33 @@ Crash regime. Overrides all quadrant logic. Maximum defense. Capital preservatio
 - Hurdle premium: **+10.0%**
 - Action: no new long entries except deeply discounted forced sales; review every active thesis for kill-condition triggers; preserve liquidity
 
+## Daily fire flags (separate signals)
+
+In addition to the 20-day color regime, two daily (1-bar) flags surface when the most recent trading day exhibits a specific shock pattern. Both are informational — they do **not** override the color or hurdle. They identify high-value forward-return windows for long-horizon investors deciding whether to add capital.
+
+### `big_blue_day`
+
+**Trigger:** SPY 1d return < −1% AND TLT 1d return > +1%.
+
+An acute risk-off shock day where bonds are hedging hard. The negative SPY/TLT correlation is working as a portfolio insurance regime, and the magnitude of the move (both directions ≥1%) marks the day as systematically actionable.
+
+Empirical edge: backed by [`backtests/spy_tlt_signals/`](../../../backtests/spy_tlt_signals/) — Sharpe 0.65 vs SPY B&H 0.43 over 24 years, with max drawdown −13.6% vs B&H −55.2%. The DD wall sits between 2- and 3-day holds, so the **actionable window is 1–2 trading days** after a fire.
+
+### `capitulation`
+
+**Trigger:** SPY 1d return < −1% AND TLT 1d return < 0 AND SPY volume > 1.5× its trailing 20-day average.
+
+Both-down panic with above-average participation — the volume condition separates capitulation from slow bleed. Classic "buy when others are fearful" regime for long-horizon investors.
+
+Same backtest backing and same 1–2 day actionable window. Lower fire frequency than `big_blue_day` (rarer event), so per-fire return magnitudes are larger but sample size is smaller.
+
+### How to read the flags
+
+- Both are boolean: `True` only on the day they fire.
+- If `True`, the persona/agent surfaces a callout in the regime output explaining the signal.
+- Operator decides whether to deploy capital; the system does not act on a fire.
+- Flags do not change the color or hurdle premium.
+
 ## Breadth flag (separate signal)
 
 The RSP-SPY 60-day spread is reported alongside the color but **does not change it**.

--- a/skills/clarion-regime-check/scripts/regime.py
+++ b/skills/clarion-regime-check/scripts/regime.py
@@ -44,6 +44,8 @@ def format_regime_output(snap: RegimeSnapshot) -> str:
         md_table(
             ["Signal", "Value"],
             [
+                ["SPY 1d return", f"{snap.spy_ret_1d:+.2%}"],
+                ["TLT 1d return", f"{snap.tlt_ret_1d:+.2%}"],
                 ["SPY 20d return", f"{snap.spy_ret_short:+.2%}"],
                 ["TLT 20d return", f"{snap.tlt_ret_short:+.2%}"],
                 ["RSP-SPY 60d spread", f"{snap.rsp_vs_spy_long:+.2%}"],
@@ -52,6 +54,22 @@ def format_regime_output(snap: RegimeSnapshot) -> str:
             ],
         ),
     ]
+    if snap.big_blue_day:
+        parts.append("")
+        parts.append(
+            f"> **Big-Blue-Day flag fired today.** SPY {snap.spy_ret_1d:+.2%}, "
+            f"TLT {snap.tlt_ret_1d:+.2%} — acute risk-off shock with bonds hedging hard. "
+            f"Historically a high-odds add-on-weakness window for long-horizon investors; "
+            f"1-2 trading day actionable window per the Phase 2 backtest."
+        )
+    if snap.capitulation:
+        parts.append("")
+        parts.append(
+            f"> **Capitulation flag fired today.** SPY {snap.spy_ret_1d:+.2%} with "
+            f"TLT {snap.tlt_ret_1d:+.2%} on above-average volume — both-down panic with "
+            f"strong participation. Buy-the-panic regime for long-horizon investors; "
+            f"1-2 trading day actionable window per the Phase 2 backtest."
+        )
     if snap.breadth_flag == "narrow":
         parts.append("")
         parts.append(

--- a/tests/test_regime.py
+++ b/tests/test_regime.py
@@ -90,6 +90,137 @@ def test_danger_drawdown_overrides_everything() -> None:
     assert "drawdown" in snap.rationale.lower()
 
 
+# ---- Daily fire flags ------------------------------------------------------
+
+
+def _series_with_last_day(
+    spy_prev_close: float,
+    spy_last_close: float,
+    tlt_prev_close: float,
+    tlt_last_close: float,
+    *,
+    spy_vol_today: int = 1_000_000,
+    spy_vol_prior_avg: int = 1_000_000,
+    n: int = 70,
+) -> tuple[list[Bar], list[Bar], list[Bar]]:
+    """Build SPY/TLT/RSP series of length n where the LAST bar has a
+    specific 1-day move and SPY volume profile (today vs trailing avg)
+    that the daily-flag rules can fire on. The 20d series is held flat
+    so the color is dominated by the last day's tiny effects only.
+
+    SPY's last bar's close = spy_last_close; bar n-2's close = spy_prev_close.
+    SPY's last bar's volume = spy_vol_today; earlier bars use spy_vol_prior_avg.
+    """
+    sd = date(2025, 1, 1)
+    # SPY: hold flat at spy_prev_close for first n-1 bars, last bar = spy_last_close
+    spy: list[Bar] = []
+    for i in range(n - 1):
+        spy.append(
+            Bar(
+                date=sd + timedelta(days=i),
+                open=spy_prev_close,
+                high=spy_prev_close,
+                low=spy_prev_close,
+                close=spy_prev_close,
+                volume=spy_vol_prior_avg,
+            )
+        )
+    spy.append(
+        Bar(
+            date=sd + timedelta(days=n - 1),
+            open=spy_last_close,
+            high=spy_last_close,
+            low=spy_last_close,
+            close=spy_last_close,
+            volume=spy_vol_today,
+        )
+    )
+    # TLT: same pattern with its own last-bar close
+    tlt: list[Bar] = []
+    for i in range(n - 1):
+        tlt.append(
+            Bar(
+                date=sd + timedelta(days=i),
+                open=tlt_prev_close,
+                high=tlt_prev_close,
+                low=tlt_prev_close,
+                close=tlt_prev_close,
+                volume=1,
+            )
+        )
+    tlt.append(
+        Bar(
+            date=sd + timedelta(days=n - 1),
+            open=tlt_last_close,
+            high=tlt_last_close,
+            low=tlt_last_close,
+            close=tlt_last_close,
+            volume=1,
+        )
+    )
+    # RSP: track SPY exactly so breadth doesn't fire
+    rsp = [
+        Bar(
+            date=b.date, open=b.open, high=b.high, low=b.low, close=b.close, volume=1,
+        )
+        for b in spy
+    ]
+    return spy, tlt, rsp
+
+
+def test_big_blue_day_fires_on_strong_negative_correlation() -> None:
+    # SPY 1d: -1.5%, TLT 1d: +1.5% → fire
+    spy, tlt, rsp = _series_with_last_day(100.0, 98.5, 100.0, 101.5)
+    snap = snapshot(spy, tlt, rsp)
+    assert snap.big_blue_day is True
+    assert snap.capitulation is False
+    assert snap.spy_ret_1d == pytest.approx(-0.015)
+    assert snap.tlt_ret_1d == pytest.approx(0.015)
+
+
+def test_big_blue_day_does_not_fire_when_spy_drop_too_small() -> None:
+    # SPY 1d: -0.5%, TLT 1d: +1.5% → no fire (SPY threshold not met)
+    spy, tlt, rsp = _series_with_last_day(100.0, 99.5, 100.0, 101.5)
+    assert snapshot(spy, tlt, rsp).big_blue_day is False
+
+
+def test_big_blue_day_does_not_fire_when_tlt_not_up_enough() -> None:
+    # SPY 1d: -1.5%, TLT 1d: +0.5% → no fire (TLT threshold not met)
+    spy, tlt, rsp = _series_with_last_day(100.0, 98.5, 100.0, 100.5)
+    assert snapshot(spy, tlt, rsp).big_blue_day is False
+
+
+def test_capitulation_fires_on_high_volume_both_down() -> None:
+    # SPY 1d: -1.5%, TLT 1d: -0.5%, volume 3M vs prior 1M avg (3x > 1.5x threshold)
+    spy, tlt, rsp = _series_with_last_day(
+        100.0, 98.5, 100.0, 99.5,
+        spy_vol_today=3_000_000, spy_vol_prior_avg=1_000_000,
+    )
+    snap = snapshot(spy, tlt, rsp)
+    assert snap.capitulation is True
+    assert snap.big_blue_day is False  # TLT is down, not up
+
+
+def test_capitulation_does_not_fire_on_normal_volume() -> None:
+    # Same SPY/TLT moves but normal volume (1x)
+    spy, tlt, rsp = _series_with_last_day(
+        100.0, 98.5, 100.0, 99.5,
+        spy_vol_today=1_000_000, spy_vol_prior_avg=1_000_000,
+    )
+    assert snapshot(spy, tlt, rsp).capitulation is False
+
+
+def test_capitulation_does_not_fire_when_tlt_up() -> None:
+    # SPY down, TLT UP, volume high — flight to safety, not capitulation. big_blue_day fires instead.
+    spy, tlt, rsp = _series_with_last_day(
+        100.0, 98.5, 100.0, 101.5,
+        spy_vol_today=3_000_000, spy_vol_prior_avg=1_000_000,
+    )
+    snap = snapshot(spy, tlt, rsp)
+    assert snap.capitulation is False
+    assert snap.big_blue_day is True
+
+
 # ---- Breadth flag (separate from color) ------------------------------------
 
 

--- a/tests/test_regime_skill.py
+++ b/tests/test_regime_skill.py
@@ -35,6 +35,10 @@ def _snap(
     hurdle: float | None = None,
     breadth_flag: str = "broad",
     rsp_vs_spy_long: float = -0.02,
+    spy_ret_1d: float = -0.003,
+    tlt_ret_1d: float = 0.002,
+    big_blue_day: bool = False,
+    capitulation: bool = False,
 ) -> RegimeSnapshot:
     return RegimeSnapshot(
         asof=date(2026, 5, 6),
@@ -46,6 +50,10 @@ def _snap(
         hurdle_rate_pct=hurdle,
         rationale="SPY -2.5% with TLT +1.2% — bond hedge working",
         breadth_flag=breadth_flag,  # type: ignore[arg-type]
+        spy_ret_1d=spy_ret_1d,
+        tlt_ret_1d=tlt_ret_1d,
+        big_blue_day=big_blue_day,
+        capitulation=capitulation,
     )
 
 
@@ -98,6 +106,40 @@ def test_format_regime_output_rationale_present(regime_mod) -> None:
     )
     out = regime_mod.format_regime_output(snap_with_rationale)
     assert "correlation breakdown" in out
+
+
+def test_format_regime_output_shows_1d_returns_in_signals_table(regime_mod) -> None:
+    out = regime_mod.format_regime_output(_snap("blue", spy_ret_1d=-0.012, tlt_ret_1d=0.015))
+    assert "SPY 1d return" in out
+    assert "TLT 1d return" in out
+    assert "-1.20%" in out
+    assert "+1.50%" in out
+
+
+def test_format_regime_output_callout_when_big_blue_day_fires(regime_mod) -> None:
+    out = regime_mod.format_regime_output(
+        _snap("blue", spy_ret_1d=-0.012, tlt_ret_1d=0.015, big_blue_day=True)
+    )
+    assert "Big-Blue-Day flag fired" in out
+    assert "actionable window" in out
+    assert "1-2 trading day" in out
+
+
+def test_format_regime_output_callout_when_capitulation_fires(regime_mod) -> None:
+    out = regime_mod.format_regime_output(
+        _snap("red", spy_ret_1d=-0.015, tlt_ret_1d=-0.005, capitulation=True)
+    )
+    assert "Capitulation flag fired" in out
+    assert "above-average volume" in out
+    assert "1-2 trading day" in out
+
+
+def test_format_regime_output_no_callouts_when_flags_quiet(regime_mod) -> None:
+    out = regime_mod.format_regime_output(
+        _snap("green", spy_ret_1d=0.002, tlt_ret_1d=0.001)
+    )
+    assert "Big-Blue-Day flag fired" not in out
+    assert "Capitulation flag fired" not in out
 
 
 def test_format_regime_output_shows_breadth_in_signals_table(regime_mod) -> None:


### PR DESCRIPTION
## What this adds

Implements the Phase 2 port validated by PR [#6](https://github.com/jingerzz/clarion-intelligence-system/pull/6) (\`backtests/spy_tlt_signals/\`). Adds two boolean daily-fire flags to \`RegimeSnapshot\`, computed from the most recent SPY/TLT bars + trailing 20d volume:

| Flag | Trigger |
|---|---|
| \`big_blue_day\` | SPY 1d return < −1% AND TLT 1d return > +1% |
| \`capitulation\` | SPY 1d return < −1% AND TLT 1d return < 0 AND SPY volume > 1.5× trailing 20d avg |

## Why as flags, not as a strategy

The backtest in #6 showed that the literal cash → SPY rotation at 1-day hold delivers **Sharpe 0.65 vs SPY B&H 0.43** with **75% max-drawdown reduction** (−13.6% vs −55.2% over 24 years). But the 1-2 day actionable window is too short for Clarion's Buffett-style operating model.

So the flags surface the *moment* — \"market just sold off hard while bonds held / volume spiked\" — and the operator decides whether to deploy capital. The system observes; it doesn't trade.

## Changes

**Lib core** (\`lib/ai_buffett_zo/regime/color.py\`):
- New constants for daily-flag thresholds: \`BBD_SPY_THRESHOLD\`, \`BBD_TLT_THRESHOLD\`, \`CAP_SPY_THRESHOLD\`, \`CAP_VOL_MULT\`, \`CAP_VOL_WINDOW\`
- \`RegimeSnapshot\` gains four new fields (all with safe defaults so existing fixtures don't break):
  - \`spy_ret_1d: float\`, \`tlt_ret_1d: float\` — 1-bar returns
  - \`big_blue_day: bool\`, \`capitulation: bool\` — fire booleans
- \`snapshot()\` populates them from the last bar + trailing 20d volume avg
- New helper \`_trailing_volume_avg()\` excluding today's bar
- Module docstring documents the flags + their actionable horizon

**CLI** (\`skills/clarion-regime-check/scripts/regime.py\`):
- Signals table gains \"SPY 1d return\" and \"TLT 1d return\" rows
- Callout block emitted when either flag fires, noting the 1-2 day actionable window

**Docs**:
- \`regime-color-guide.md\` — new \"Daily fire flags\" section above the existing breadth-flag section, with backtest citation
- \`PERSONAS-AND-RULES.md\` Persona 2 (Macro Sentinel) — flag reference table + new hard rule that flags are informational, not commands

## Tests

587 pass (was 577 on main; **+10 new**):
- 6 unit tests for lib flag detection covering each fire/no-fire branch (BBD fires/doesn't on each component; capitulation fires only when all three conditions met; capitulation correctly doesn't fire when TLT is up — that path goes to BBD instead)
- 4 tests for CLI rendering: 1d return rows in signals table, BBD callout, capitulation callout, no callouts when flags quiet
- All other fixture-using test files unaffected via the dataclass-defaults trick

## Backwards compatibility

The four new \`RegimeSnapshot\` fields have defaults (\`False\` and \`0.0\`), so any test fixture or downstream caller constructing a snapshot manually still works. Production callers go through \`snapshot()\` which always populates correctly. The defaults are a fixture-convenience choice — in real flow the fields are always set from data.

## Files changed (6)

\`\`\`
docs/PERSONAS-AND-RULES.md
lib/ai_buffett_zo/regime/color.py
skills/clarion-regime-check/references/regime-color-guide.md
skills/clarion-regime-check/scripts/regime.py
tests/test_regime.py
tests/test_regime_skill.py
\`\`\`

## Sync impact

After merge:
- **No Zo skills repo sync needed.** Everything changed lives in the lib (ships via \`git pull\`), the clarion-regime-check sibling skill (refreshed by clarion-setup's auto-install step), or source-only docs. \`External/clarion-setup/\` in \`zocomputer/skills\` is untouched.
- **Existing-user upgrade path**: \`git pull\` → re-run \`clarion-setup\` → restart \`sec-indexer\`. If Persona 2 is installed in Zo Settings, re-paste from the updated \`docs/PERSONAS-AND-RULES.md\`.

## What's still deferred (Phase 3 candidates)

- Threshold sensitivity analysis (does ±0.5% on the 1% thresholds materially change the edge?)
- Streak / dominant-color summary over the last N trading days (the original deferred Phase 2 observability item)
- Magnitude-graded flag (small/medium/large fire rather than boolean) if you ever want richer signaling