### PR TITLE
docs: routing tie-breaker + flag-aware Step 0 for Personas 3, 4, 6

### DIFF
--- a/docs/PERSONAS-AND-RULES.md
+++ b/docs/PERSONAS-AND-RULES.md
@@ -163,6 +163,12 @@ Your job is to run quantitative value screens, refresh watchlist prices, surface
 ### Mode A — Watchlist Update (daily / pre-market)
 Trigger phrases: "watchlist update", "anything moving?", "what's hit my watchlist?", "is anything close to a trigger?"
 
+0. **State current regime context first.** Run regime check before anything else:
+   ```bash
+   python /home/workspace/Skills/clarion-regime-check/scripts/regime.py
+   ```
+   Lead with regime color + hurdle in one line. If `big_blue_day` or `capitulation` fires, surface the callout — those are exactly the days a watchlist update is most actionable (the daily flags identify high-odds add-on-weakness windows).
+
 1. Run the update script:
    ```bash
    python /home/workspace/Skills/clarion-watchlist-update/scripts/update.py
@@ -290,6 +296,13 @@ You do not opine without evidence. You do not skip the regime context. You do no
 ---
 
 ## Workflow
+
+### Step 0 — Establish regime context
+Run regime check first so every verdict is grounded in the current macro:
+```bash
+python /home/workspace/Skills/clarion-regime-check/scripts/regime.py
+```
+State regime color + hurdle in one line before proceeding. If `big_blue_day` or `capitulation` fires, surface the callout — those are exactly the days a long-horizon investor wants to know about while reading a stock evaluation (an Add verdict on a big_blue_day or capitulation day carries materially different operator weight than the same verdict on a quiet day).
 
 ### Step 1 — Check indexing
 Before any analysis, run:
@@ -544,6 +557,12 @@ Your role is not to help rationalize positions. It is to enforce discipline on a
 
 When the user asks to monitor theses, check positions, review portfolio health, or asks about a specific ticker's action:
 
+0. **State current regime + any active daily flags first.** Run:
+   ```bash
+   python /home/workspace/Skills/clarion-regime-check/scripts/regime.py
+   ```
+   Lead with regime color. If `big_blue_day` or `capitulation` fires, surface the callout — those are the days you may want to **ADD** to existing high-conviction positions, complementing the monitor's EXIT / REDUCE / HOLD output. The monitor surfaces what's breaking down; the regime daily flags surface what's an opportunity. Both belong in the same response.
+
 1. Run the thesis monitor script:
    - Full review (weekly): `python /home/workspace/Skills/clarion-thesis-monitor/scripts/monitor.py`
    - Quick check (daily, kill conditions + price + Risk Env only): add `--quick`
@@ -713,6 +732,16 @@ Good: "We got the regime call right (ORANGE) but entered PG too early — $148 v
 ---
 
 ## Rules
+
+**Routing tie-breaker (applies to Rules 5–10).** When a user query matches more than one routing rule, switch to the *earliest* matching persona in the decision cascade. Cascade order:
+
+```
+Macro Sentinel → Value Screener → Analyst → Thesis Architect → Portfolio Manager → LP Voice
+```
+
+Example: *"Should I be in NVDA right now given the regime?"* matches Rule 5 (Analyst) AND Rule 6 (Macro Sentinel). Macro Sentinel is earlier in the cascade — route there first. After stating regime + hurdle, the Macro Sentinel can hand off to the Analyst for the NVDA-specific question.
+
+Within any active specialist persona, the persona's own prompt still enforces its pre-flight discipline (e.g., the Analyst states regime + hurdle before any verdict; the Thesis Architect runs four gates before scaffolding). The tie-breaker only governs which persona handles the *initial* response to a multi-intent query.
 
 **Note on scope:** Rules 1 and 2 below configure a personal memory layer that is **not installed by `clarion-setup`**. They are documented here as part of the author's complete Zo configuration, but require additional setup outside this repo. A new Clarion user can safely skip Rules 1 and 2 — Rule 3 (live market data) is the only Clarion-domain rule and applies to all users.
 


### PR DESCRIPTION
## What this fixes

Three architectural gaps surfaced in the systems review of PR #7:

### 1. Multi-intent routing tie-breaker
Before: a query matching multiple routing rules (Rules 5–10) produced non-deterministic behavior — whichever rule fired first won, but the doc didn't define order. Common cases like *\"should I be in NVDA right now given the regime?\"* (matches Rule 5 Analyst AND Rule 6 Macro Sentinel) had no defined answer.

After: an explicit tie-breaker block at the top of the Rules section says **route to the earliest persona in the decision cascade**:
\`\`\`
Macro Sentinel → Value Screener → Analyst → Thesis Architect → Portfolio Manager → LP Voice
\`\`\`
With a worked example and a boundary note that the tie-breaker only governs the *initial* response — once a specialist persona is active, its own pre-flight discipline still runs.

### 2. Daily fire flags now reach Personas 3, 4, and 6
Before: PR #8 added \`big_blue_day\` and \`capitulation\` flags to \`RegimeSnapshot\`, but only Persona 2 (Macro Sentinel) was updated to surface them. Personas 3, 4, 6 all consume regime as input but had no path to see daily flags unless the user explicitly routed through Macro Sentinel first.

After: each of Personas 3 (Watchlist Update mode), 4 (Analyst), 6 (Portfolio Manager) gains a **Step 0 — run regime check first**, with persona-specific framing for why the flags matter in that context:

- **Persona 3 Mode A**: \"those are exactly the days a watchlist update is most actionable\"
- **Persona 4 Analyst**: \"an Add verdict on a big_blue_day day means something materially different than the same verdict on a quiet day\"
- **Persona 6 PM**: \"the monitor surfaces what's breaking down; the regime flags surface what's an opportunity. Both belong in the same response\"

### 3. Cascade enforcement (load-bearing for evaluation gate)
The Step 0 additions also formalize what was previously implicit prompt discipline: every Analyst response now provably begins with regime context, not just \"never give a verdict without stating hurdle rate.\" Same for the PM. The decision cascade's *full-ordering* (must screen before evaluating, etc.) stays aspirational — that wasn't worth the gate friction.

## Personas NOT changed and why

- **Persona 1 (Data-First Plain Talk)**: default tone, no regime context needed.
- **Persona 2 (Macro Sentinel)**: IS the regime persona — already shows flags via PR #8.
- **Persona 5 (Thesis Architect)**: regime context arrives via Gate 2 (eval-run prerequisite), since the eval persona now starts with regime in its Step 0. Adding redundant Step 0 here would double-fetch. The existing Gate 6 regime compatibility check at end of scaffold stays.
- **Persona 6 — wait, that's covered above.**
- **Persona 7 (LP Voice)**: letter writing auto-fills regime via \`letter.py\` script. No operator-visible decision depends on daily flags here.

## Footprint

- One file changed: \`docs/PERSONAS-AND-RULES.md\`
- +29 lines, 0 deletions
- No code, no tests affected. Full suite still 587 passing.

## What's still queued (architecture polish, separate PRs)

- **Rule 11 — return to Persona 1** for non-investment questions while a specialist is active
- **LP Voice consolidation** — 22+ directives in one persona; could be layered cleaner
- **Maintenance section update** — flag UUID-drift maintenance trigger
- **Setup ergonomics** — \`scripts/print-personas-and-rules.py\` to reduce the 17+ copy-pastes a new user has to do

These are real but lower-priority than the three load-bearing decisions this PR settles.