### PR TITLE
docs: deduplicate LP Voice — fold Anti-patterns into Hard rules

### DIFF
--- a/docs/PERSONAS-AND-RULES.md
+++ b/docs/PERSONAS-AND-RULES.md
@@ -713,20 +713,10 @@ Good: "We got the regime call right (ORANGE) but entered PG too early — $148 v
 
 1. **Never edit past quarters retroactively.** The timestamped record is the point. Hindsight commentary goes in brackets in the current quarter's entry — never as edits to old sections. The script enforces this; you enforce it too.
 2. **The narrative sections are human-written.** You can scaffold, suggest, and sharpen — but What We Did and What We Learned must come from the principal's actual recollection. Never fabricate narrative content from filing data.
-3. **Show the reasoning, not just the outcome.** A quarterly entry that only chronicles wins is fiction. Every position mentioned must include: entry reasoning, what the filing showed, what the regime was.
+3. **Show the reasoning, not just the outcome.** A quarterly entry that only chronicles wins is fiction. Every position mentioned must include: entry reasoning, what the filing showed, what the regime was. Vague performance claims ("performance was strong", "we did well") must be replaced with a specific number and a benchmark before the section is accepted.
 4. **Mistakes section is mandatory.** If the user tries to skip it or write a placeholder, push back: "This section is the most valuable one in the letter. One named mistake, minimum."
 5. **Keep it concise.** Each quarterly entry should be readable in 5–10 minutes. Link to thesis files for depth — do not duplicate them.
 6. **Never finalize before all four quarters are populated.** The script enforces this; surface it clearly if the user tries.
-
----
-
-## Anti-patterns
-
-- Never let "performance was strong" stand without a specific number and benchmark
-- Never let a position be mentioned without its entry reasoning at the time (not hindsight)
-- Never skip or accept a placeholder Mistakes section
-- Never edit a past quarter without stating the reason and using `--force`
-- Never write the narrative sections yourself — scaffold and challenge, never fabricate
 ```
 
 ---


### PR DESCRIPTION
## What this does

Persona 7 (LP Voice) had **21 directives** (10 voice rules + 6 hard rules + 5 anti-patterns), with three pairs of literal duplicates:

| Hard rule | Anti-pattern that said the same thing |
|---|---|
| #1 Never edit past quarters retroactively | #4 Never edit a past quarter without `--force` |
| #2 Narrative sections are human-written | #5 Never write the narrative sections yourself |
| #4 Mistakes section mandatory | #3 Never skip or accept a placeholder Mistakes section |

Of the remaining two anti-patterns:
- **Position without entry reasoning** — already covered by hard rule #3.
- **\"Performance was strong\" without numbers** — the only substantive item not yet covered. Folded into hard rule #3 as an explicit pushback clause.

The whole `## Anti-patterns` section is removed; nothing of substance is lost.

## Result

**21 → 16 directives, zero content removed.** Pure deduplication, no design judgment.

## Why this matters

Three pairs of literal duplicates is maintenance debt waiting to drift. Future edits to one side of a duplicate would silently diverge from the other. A single source of truth per directive means one place to update when the rule itself evolves.

## Footprint

- One file: \`docs/PERSONAS-AND-RULES.md\`
- −10 net lines (12 removed, 1 expanded line, plus a tiny consolidation)
- No code, no tests. 587 still passing.

## What's still queued (one item, separate concern)

- **`scripts/print-personas-and-rules.py`** — automate the 17+ copy-pastes a new user does at install time. Tooling work, not docs. Separate PR.