### PR TITLE
clarion-setup: collapse install flow into one prompt + one batched human checkpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Built around principles from Berkshire Hathaway and Buffett's annual letters, ad
 
 ## Install
 
-A brand-new Zo user gets fully set up in ~3-5 minutes. Most of that is the one-time access-token step.
+A brand-new Zo user gets fully set up in ~3-5 minutes. The entire install is two chat prompts and one batched human checkpoint near the end (your SEC EDGAR name+email and creating one Zo secret). Everything else — code, library, data tree, sibling skills, background service, personas, routing rules — is autonomous.
 
 ### 1. Install the bootstrap skill
 
@@ -28,67 +28,51 @@ In Zo chat:
 
 > set up Clarion
 
-The skill will:
+The skill runs autonomously through these steps:
 
 1. Clone this repo into `/home/workspace/clarion-intelligence-system`
 2. Install the `ai_buffett_zo` Python library (`uv pip install -e lib/`)
 3. Create the `~/clarion/` workspace tree (`data/`, `sec/`, `queue/`, `theses/`, `watchlists/`, `letters/`)
-4. Write `~/clarion/config.json` with sane model defaults (all Zo-hosted, routed through `/zo/ask`)
-5. Pause and ask you to create the `ZO_API_KEY` secret (next step)
-6. Register the `sec-indexer` background service for you
+4. Write `~/clarion/config.json` with sane model defaults (all Zo-hosted)
+5. Auto-install all nine sibling `clarion-*` skills under `/home/workspace/Skills/`
+6. Register the `sec-indexer` background service (will be in FATAL state until step 3 below — that's expected)
+7. Install all 7 Clarion personas in Zo Settings → AI → Personas
+8. Install the 8 Clarion routing rules (Rule 3 + Rules 5–11) in Zo Settings → AI → Rules
 
-Setup is idempotent — safe to re-run any time to pull source updates (see [Updating](#updating) below).
+Then it pauses for **one batched human checkpoint** — described in Step 3 below. After your input, the skill resumes autonomously: writes your SEC EDGAR identification to `~/clarion/config.json`, restarts the `sec-indexer` service, verifies it's running, and reports completion.
 
-### 3. Create the `ZO_API_KEY` secret (one-time)
+Setup is idempotent — safe to re-run any time to pull source updates. It will ask before replacing any personas or rules you've customized.
 
-The `sec-indexer` runs as a persistent background service that needs to call Zo models on your behalf. It needs a long-lived bearer token (chat skills get one auto-injected, but background services don't). The token is **Zo-issued** and bills against your Zo monthly credits — same pool as chat usage. **No external API keys.**
+### 3. The one batched human checkpoint
 
-When `clarion-setup` prompts you:
+When the skill pauses, it asks for **two things at once** — surface them together so you can multitask:
 
-**Step 3a — Create an access token:**
+**(a) SEC EDGAR identification.** SEC requires every API consumer to identify itself in the User-Agent header. Type one line in chat:
+
+```
+Jane Doe jane@example.com
+```
+
+(Your real name and email — sent in every SEC request from your machine. Only you and SEC see it. Required by SEC's [fair-access policy](https://www.sec.gov/os/accessing-edgar-data).)
+
+**(b) Create the `ZO_API_KEY` secret in Zo Settings.** The `sec-indexer` background service needs a Zo-issued token to call Zo models on your behalf. Chat skills get a token auto-injected; background services don't, so you have to create one explicitly. The token is **Zo-issued** and bills against your Zo monthly credits — same pool as chat usage. **No external API keys involved.**
+
+In a separate browser tab while you reply to (a):
 
 1. Open Zo Settings (top-right menu icon → **Settings**).
-2. Go to **Advanced → Access Tokens**.
-3. Click **Create token**. Name it anything (`clarion-sec-indexer` is a good default).
-4. **Copy the token value** — it starts with `zo_sk_`. You'll paste it in the next step.
+2. Go to **Advanced → Access Tokens**. Click **Create token**. Name it anything (`clarion-sec-indexer` is a good default). **Copy the token value** — it starts with `zo_sk_`.
+3. Go to **Advanced → Secrets**. Click **Create secret**.
+4. **Name:** type **exactly** `ZO_API_KEY` (uppercase, with the underscore — the indexer looks up this exact name; lowercase or hyphens won't work).
+5. **Value:** paste the token from step 2.
+6. Save.
 
-**Step 3b — Save it as a secret:**
-
-1. In the same Settings area, go to **Advanced → Secrets**.
-2. Click **Create secret**.
-3. **Name:** type **exactly** `ZO_API_KEY` (uppercase, with the underscore — the indexer service looks up this exact name; lowercase or hyphens won't work).
-4. **Value:** paste the token from Step 3a.
-5. Save.
-
-**Step 3c — Confirm:** Reply `done` in the chat. Zo will register the `sec-indexer` service and finish setup automatically.
+Once both are done — your SEC identification typed in chat AND the `ZO_API_KEY` secret created — reply `done`. The skill will write your SEC identification to config.json, restart `sec-indexer`, verify it's running, and report.
 
 That's the only manual config in the whole install.
 
-> **If Zo's chat agent didn't pause and ask you for the secret in chat,** prompt it explicitly: *"walk me through creating the ZO_API_KEY secret step by step."* The full instructions live in this README and in the `clarion-setup` skill's output — the agent should paste them verbatim.
+> **If Zo's chat agent didn't pause and ask you,** prompt it explicitly: *"walk me through the human checkpoint for Clarion setup — I need to provide my SEC EDGAR identification and create the ZO_API_KEY secret."* The full instructions live in the `clarion-setup` skill's SKILL.md — the agent should walk you through them.
 
-### 4. Install the personas and rules (one-time)
-
-`clarion-setup` installs all 10 sibling skills automatically — no extra "install the X skill" steps. The only remaining install step is configuring the **personas and rules** documented in [`docs/PERSONAS-AND-RULES.md`](./docs/PERSONAS-AND-RULES.md). They turn a generic Zo chat into a specialized investment team with auto-routing.
-
-Paste this into Zo chat:
-
-> I want you to install the Clarion Intelligence System personas and rules. Fetch the source of truth: `https://raw.githubusercontent.com/jingerzz/clarion-intelligence-system/main/docs/PERSONAS-AND-RULES.md`
->
-> Then:
->
-> 1. **Install all 7 personas** — each persona's prompt is in a triple-backtick code block under sections `## Persona 1` through `## Persona 7`. Use the persona name from the section heading. Paste the code-block contents verbatim into Zo Settings → AI → Personas.
->
-> 2. **Install Rules 3, 5–10, and 11** under `## Rules`. Skip Rules 1, 2, and 4 — the doc's scope notes mark them as operator-personal (memory layer and Zo Space verification not installed by Clarion). Copy each rule's Condition and Instruction text verbatim into Zo Settings → AI → Rules.
->
-> 3. **Re-link UUIDs in Rules 5–11.** When you created the personas in Step 1, Zo assigned them new UUIDs. Replace the doc's placeholder UUIDs with yours, matching by persona name (Rule 5 → Clarion Analyst, Rule 6 → Clarion Macro Sentinel, Rule 7 → Portfolio Manager, Rule 8 → Thesis Architect, Rule 9 → Value Screener, Rule 10 → LP Voice, Rule 11 → Persona 1 Data-First Plain Talk).
->
-> 4. **Verify with one query per routing rule** — tell me which switched personas correctly: *"Evaluate NVDA"* (→ Analyst), *"What's the regime today?"* (→ Macro Sentinel), *"Check my thesis health"* (→ Portfolio Manager), *"Run a value screen on AAPL,MSFT,GOOG"* (→ Value Screener), *"Write a thesis on NVDA"* (→ Thesis Architect), *"Update the Q1 letter"* (→ LP Voice), *"What time is it in New York?"* (→ Persona 1).
->
-> If anything fails, stop and tell me before continuing.
-
-This is the one place we still ask for human-in-the-loop pasting — the Zo persona/rule API isn't yet exposed for bulk import. Once it is, this step will be replaced by a single registration call.
-
-### 5. Use it conversationally
+### 4. Use it conversationally
 
 That's it. Now ask Zo things like:
 
@@ -106,13 +90,9 @@ When upstream ships fixes, re-run `clarion-setup` to pull them down:
 
 > set up Clarion
 
-This `git pull`s the source, re-installs the library, and re-runs the data-tree / config steps (all idempotent).
+This `git pull`s the source, re-installs the library, refreshes the sibling skills under `/home/workspace/Skills/`, and — if there are doc updates — asks you before replacing any customized personas or rules. On a clean re-run (you didn't customize anything, secret already exists, sec_user_agent already set), the human checkpoint in step 3 is skipped automatically and the whole flow is autonomous.
 
-**Important:** an editable install (`uv pip install -e`) does NOT reload an already-running service. The `sec-indexer` keeps the modules it imported at startup in memory. After re-running setup, ask Zo to restart the service:
-
-> restart the sec-indexer service
-
-(Zo uses its `update_user_service` tool to do this.) Then any updated source code is loaded into the running process.
+The skill restarts `sec-indexer` automatically as part of the re-run, so updated library code is loaded into the running process. No separate "restart the service" command needed.
 
 ## Skills
 

--- a/skills/clarion-setup/SKILL.md
+++ b/skills/clarion-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clarion-setup
-description: Bootstraps the Clarion Intelligence System on Zo Computer. Run this once after installing — clones the source repo, installs the ai_buffett_zo Python library, creates the workspace data tree under /home/workspace/clarion/ (auto-detected on Zo), auto-installs all nine sibling clarion-* skills (regime-check, sec-research, single-stock-eval, expected-return-calc, value-screener, thesis-write, thesis-monitor, watchlist-update, living-letter-update) under /home/workspace/Skills/, and registers the sec-indexer background service. Idempotent (safe to re-run; refreshes installed skills with upstream copies). This is the only Clarion skill a user needs to install manually — every other clarion-* skill is installed by this one. Use when the user asks to "set up Clarion" or "install Clarion".
+description: Bootstraps the Clarion Intelligence System on Zo Computer. Run this once after installing — clones the source repo, installs the ai_buffett_zo Python library, creates the workspace data tree under /home/workspace/clarion/ (auto-detected on Zo), auto-installs all nine sibling clarion-* skills (regime-check, sec-research, single-stock-eval, expected-return-calc, value-screener, thesis-write, thesis-monitor, watchlist-update, living-letter-update) under /home/workspace/Skills/, registers the sec-indexer background service, and installs the 7 Clarion personas + 8 routing rules into Zo Settings. Idempotent (safe to re-run; asks before replacing customized personas/rules). The only manual step is one batched human checkpoint near the end (SEC EDGAR name + email, and creating the ZO_API_KEY secret). Use when the user asks to "set up Clarion" or "install Clarion".
 metadata:
   author: cis.zo.computer
   category: External
@@ -10,13 +10,15 @@ metadata:
 
 # Clarion Setup
 
-Bootstraps Clarion Intelligence System on a Zo workspace. Run this once before any other `clarion-*` skill.
+Bootstraps the Clarion Intelligence System on a Zo workspace. Run this once before any other `clarion-*` skill.
 
-## What you do
+## Flow at a glance
 
-Run the steps below in order. Stop and surface any failure to the user immediately — do not proceed past a failure.
+This skill is designed for a **single-prompt install** experience. Steps 1–5 run autonomously (clone, library, data tree, register service, install personas + rules). Step 6 is one batched human checkpoint — the user supplies their SEC EDGAR identification and creates the `ZO_API_KEY` secret in Zo Settings. Steps 7–9 resume autonomously to apply the user's input, restart the service, verify it's running, and report.
 
-### Step 1 — Clone or update the source repo
+Walk through the steps below in order. Stop and surface any failure to the user immediately — do not proceed past a failure.
+
+## Step 1 — Clone or update the source repo
 
 The repo holds the Python library, the `sec-indexer` service code, and templates.
 
@@ -32,7 +34,7 @@ If it exists, update it:
 git -C /home/workspace/clarion-intelligence-system pull --ff-only
 ```
 
-### Step 2 — Run the setup script
+## Step 2 — Run the setup script
 
 ```bash
 python /home/workspace/clarion-intelligence-system/skills/clarion-setup/scripts/setup.py
@@ -42,38 +44,18 @@ The script is idempotent. It will:
 
 - Install the `ai_buffett_zo` library editable (auto-detects whether to use `--system`)
 - Create the `~/clarion/{data/equities,sec,queue,theses,watchlists,letters}/` data tree
-- Write a default `~/clarion/config.json` (preserves any existing config)
+- Write a default `~/clarion/config.json` if missing (preserves any existing config — including any `sec_user_agent` you already customized)
 - Verify the `sec-indexer` console script is on PATH
 - Install every sibling `clarion-*` skill from the repo into `/home/workspace/Skills/` (refreshes any already-installed copies; pass `--skip-skills` to opt out)
 - Print service registration parameters between `--- BEGIN SERVICE_REGISTRATION ---` and `--- END SERVICE_REGISTRATION ---`
+- Print a `USER_ACTION_REQUIRED` block (you'll surface this in Step 6)
 - Print a final `SETUP_RESULT: ok` line on success, or `SETUP_RESULT: error: <reason>` on failure
 
 If you do NOT see `SETUP_RESULT: ok`, surface the error to the user verbatim and stop.
 
-### Step 3 — Confirm or create the ZO_API_KEY secret
+## Step 3 — Register the sec-indexer service
 
-**Scope:** This step is only needed because of the `sec-indexer` **background service**. The other Clarion skills (`clarion-regime-check`, `clarion-sec-research`, etc.) run inside chat agent turns, which auto-inject `ZO_CLIENT_IDENTITY_TOKEN`, so they need no token setup. The indexer runs as a persistent process outside agent turns, has no auto-injected identity, and so needs a long-lived bearer.
-
-The token is **not** an external provider key (no OpenAI / Anthropic / Minimax keys involved). It's Zo-issued and calls made with it are billed against the user's Zo monthly credit pool, same as their chat usage.
-
-**Decision — fresh install vs. re-run:**
-
-- If the user already has a Zo secret named exactly `ZO_API_KEY` (most likely on a re-run), skip to Step 4.
-- Otherwise (most likely on a first install), do the verbatim-paste step below.
-
-**CRITICAL — paste the user-action block verbatim.** The setup script's stdout includes a block bounded by `--- BEGIN USER_ACTION_REQUIRED ---` and `--- END USER_ACTION_REQUIRED ---`. **Copy the contents of that block (everything between the two sentinels) into the chat exactly as written. Do not summarize, paraphrase, or condense.**
-
-The block is dummy-proofed for a non-technical user: it has the exact menu paths, the exact secret name (`ZO_API_KEY`, uppercase, with underscore — the most error-prone part), the numbered sequence, and a note about UI variations. Compressing it removes the dummy-proofing.
-
-After pasting the block:
-
-1. Wait for the user to reply with `done` (or any clear confirmation).
-2. If they reply with a question instead of confirmation (e.g. "I can't find Settings"), help them — but lead with the same explicit substeps from the user-action block, not your own paraphrase.
-3. Once confirmed, proceed to Step 4.
-
-### Step 4 — Register the sec-indexer service
-
-Use the `register_user_service` agent tool with these exact parameters (also printed by setup.py in the SERVICE_REGISTRATION envelope):
+Use the `register_user_service` agent tool with the parameters printed in the `SERVICE_REGISTRATION` envelope:
 
 - **label**: `sec-indexer`
 - **mode**: `process`
@@ -88,37 +70,133 @@ Use the `register_user_service` agent tool with these exact parameters (also pri
 {"ZO_API_KEY": "$ZO_API_KEY", "CLARION_DATA_ROOT": "/home/workspace/clarion"}
 ```
 
-Do **not** wrap it in quotes and escape it like `"{\"ZO_API_KEY\": \"$ZO_API_KEY\", ...}"`. If the tool call appears to require escape sequences inside `env_vars`, stop and re-form the call — the parameter is an object, not a string. Models that try to escape this end up generating malformed input that either fails outright (`register_user_service` returns a runner-stopped error) or — worse — succeeds with corrupted values (env vars inlined into the entrypoint shell-string, trailing XML-tag artifacts appended to the entrypoint, `CLARION_DATA_ROOT` silently dropped). The wrong-values-but-success failure mode is the dangerous one and Step 5 catches it; the prevention is to get the env_vars shape right here.
+Do **not** wrap it in quotes and escape it like `"{\"ZO_API_KEY\": \"$ZO_API_KEY\", ...}"`. If the tool call appears to require escape sequences inside `env_vars`, stop and re-form the call — the parameter is an object, not a string. Models that try to escape this end up generating malformed input that either fails outright or — worse — succeeds with corrupted values (env vars inlined into the entrypoint shell-string, trailing XML-tag artifacts appended to the entrypoint, `CLARION_DATA_ROOT` silently dropped). The verification at Step 8 catches the corrupted-success case; the prevention is to get the env_vars shape right here.
 
-The `$ZO_API_KEY` value is shell-style syntax telling Zo to resolve from the user's secret of the same name (created in Step 3) at service start. The `CLARION_DATA_ROOT` value is a literal path — it pins the indexer's writes to the same data root chat skills read from, so SEC filings land in the user-visible workspace and not in `/root/clarion/` when the service runs as root. Use the snake_case parameter names exactly — `workdir` and `env_vars` — these are the canonical keys Zo's tool accepts.
+**Expected state after Step 3: the service is in `FATAL` or `BACKOFF`.** This is normal and expected. `$ZO_API_KEY` resolves from a Zo secret that doesn't exist yet (the user creates it in Step 6). The supervisor will try to launch `sec-indexer`, the binary will fail to authenticate against Zo's API, and the service will retry-backoff. **Do NOT call `service_doctor` yet. Do NOT delete and re-register. Continue to Step 4.** The restart in Step 7, after the secret exists, brings the service to RUNNING.
 
-Confirm registration succeeded (the tool should return a service ID like `svc_…`).
+If `register_user_service` itself returns an error (not just a FATAL state — an actual tool error), check the env_vars formatting above first, then surface the error.
 
-### Step 5 — Verify the service is actually running (do not skip)
+## Step 4 — Install the 7 Clarion personas
 
-**Critical:** `register_user_service` returns success when the registration is *recorded*, not when the process is *running*. The platform does not validate that the entrypoint is a parseable shell command, nor that env_vars were correctly formatted — those checks are on you, and silent-corruption failure modes do occur when model output drifts on the JSON-escaping path. Verify the service actually started before reporting completion.
+Read `/home/workspace/clarion-intelligence-system/docs/PERSONAS-AND-RULES.md`.
 
-Check service status using Zo's supervisor-status tool (`service_doctor` on the current Zo platform; use the equivalent if your environment differs):
+For each of the 7 personas — sections `## Persona 1 — Data-First Plain Talk` through `## Persona 7 — Clarion LP Voice`:
+
+1. **Extract the persona name** from the section heading. Examples:
+   - `## Persona 1 — Data-First Plain Talk` → name is `Data-First Plain Talk`
+   - `## Persona 2 — Clarion Macro Sentinel` → name is `Clarion Macro Sentinel`
+2. **Extract the persona's prompt text** — it's the contents of the *outermost* triple-backtick code block within the persona's section (before the next `## Persona` heading or the next top-level section). Note: persona prompts contain *nested* triple-backtick blocks for bash examples; you want the outermost one only.
+3. **Check whether a persona with this name already exists**:
+   - Call `list_personas()` and filter client-side by `name`.
+   - If a match exists, ask the user: *"I see an existing Clarion persona named '\<NAME\>'. Replace it with the latest version from the doc? (yes/no)"* Wait for the answer.
+     - If **yes**: call `delete_persona(persona_id=<existing_id>)`, then proceed to create.
+     - If **no**: skip this persona entirely; do not create a duplicate. Note the existing `id` in the persona-ID map for Step 5.
+   - If no match exists, proceed to create.
+4. **Create the persona**: call `create_persona(name="<extracted name>", prompt="<extracted prompt>")`. The tool response contains the new persona's `id`. If the response shape is unexpected and you can't find the `id`, fall back to calling `list_personas()` again and filtering by name to recover the new id.
+5. **Record** the mapping `{persona_name → persona_id}` for use in Step 5.
+
+After all 7 personas, you should have a complete mapping covering all 7 Clarion persona names. Surface any persona that was skipped (user said "no" to replacement) — the corresponding rule in Step 5 still needs an ID to reference, so the existing persona's ID must be in the map.
+
+## Step 5 — Install Clarion rules
+
+Read the same `PERSONAS-AND-RULES.md` file. **Install Rules 3, 5, 6, 7, 8, 9, 10, and 11. SKIP Rules 1, 2, and 4** — they reference operator-personal infrastructure not installed by Clarion (memory layer, Zo Space verification). The doc has explicit scope notes confirming this.
+
+For each rule to install:
+
+1. **Extract the rule's Condition text** — the prose body after `**Condition:**` (a single paragraph, not in a code block).
+2. **Extract the rule's Instruction text** — the contents of the triple-backtick block under `**Instruction:**`.
+3. **For Rules 5–11 (the routing rules)**, the Instruction text contains a persona ID. The doc's checked-in value is the author's instance-specific UUID OR the placeholder `<your Persona N UUID>` (for Rule 11). **Replace it with the actual persona ID** you captured in Step 4, matched by name:
+   - Rule 5 (stock evaluation) → `Clarion Analyst`
+   - Rule 6 (regime questions) → `Clarion Macro Sentinel`
+   - Rule 7 (thesis monitoring / portfolio status) → `Clarion Portfolio Manager`
+   - Rule 8 (thesis writing) → `Clarion Thesis Architect`
+   - Rule 9 (value screens) → `Clarion Value Screener`
+   - Rule 10 (investor letter) → `Clarion LP Voice`
+   - Rule 11 (return to default) → `Data-First Plain Talk`
+4. **Check whether a Clarion routing rule with this condition already exists**:
+   - Call `list_rules()` and compare each existing rule's condition text to the one you're about to install. Compare the first ~80 characters (handles minor wording variations across doc versions).
+   - If a match exists, ask the user: *"I see an existing Clarion rule for '\<condition snippet\>'. Replace it? (yes/no)"* Wait for the answer.
+     - If **yes**: call `delete_rule(rule_id=<existing_id>)`, then proceed to create.
+     - If **no**: skip this rule.
+   - If no match exists, proceed to create.
+5. **Create the rule**: call `create_rule(instruction="<substituted instruction>", condition="<condition>")`.
+
+Total expected after Step 5: **8 Clarion rules installed** (Rule 3 + Rules 5–11).
+
+## Step 6 — Batched human checkpoint (the only manual step)
+
+**Pre-check (skip the whole checkpoint on a clean re-run).** Before asking the user for anything, check both of:
+
+1. `/home/workspace/clarion/config.json`'s `sec_user_agent` field — is it the placeholder `Clarion Intelligence System (clarion@example.com)`, or a real user value?
+2. `service_doctor(service="sec-indexer")` — is the service already RUNNING with non-zero uptime? (If yes, the `ZO_API_KEY` secret already exists, since the service couldn't have started without it.)
+
+If `sec_user_agent` is a real value AND the service is already RUNNING, **skip Step 6 entirely** — there's nothing for the user to do. Tell the user *"detected a complete prior install — skipping the human checkpoint and going straight to a refresh restart."* Jump to Step 7b (restart only, no config.json write needed).
+
+Otherwise, you need at least one of two inputs from the user. **Surface both together so they can multitask** — the user can type their SEC identification in chat while simultaneously navigating Zo Settings to create the secret.
+
+### Input A — SEC EDGAR identification
+
+First, check `/home/workspace/clarion/config.json` — read the `sec_user_agent` field. If it is the placeholder `Clarion Intelligence System (clarion@example.com)`, you need a real value from the user. Ask:
+
+> **SEC EDGAR requires Clarion to identify itself in every API request.** Type your name and email in the format: `Jane Doe jane@example.com`. This will be sent in the User-Agent header of every SEC request from your machine — only you and the SEC see it. SEC's [fair-access policy](https://www.sec.gov/os/accessing-edgar-data) asks every API consumer to identify themselves.
+>
+> Reply with that one line. While you're doing that, also start Input B below.
+
+If `sec_user_agent` is already a non-placeholder value (a previous install set it), **skip Input A** and use what's already in config.json.
+
+### Input B — Create the `ZO_API_KEY` secret in Zo Settings
+
+The setup script's stdout includes a block bounded by `--- BEGIN USER_ACTION_REQUIRED ---` and `--- END USER_ACTION_REQUIRED ---`. **Paste the contents of that block (everything between the two sentinels) into chat verbatim**, below your Input A request. Do not summarize, paraphrase, or condense — the block is dummy-proofed for non-technical users with exact menu paths and the exact secret name (`ZO_API_KEY`, uppercase, with underscore — the most error-prone part).
+
+Wait for the user to reply with:
+- A line in the format `Name email@example.com` (for Input A) — **unless** you already had a non-placeholder `sec_user_agent`, in which case there's nothing to wait for here.
+- The word `done` (or any clear confirmation) that they've created the `ZO_API_KEY` secret (for Input B).
+
+If the user only replies to one of the two, prompt for the other before continuing.
+
+## Step 7 — Apply user inputs and restart the service
+
+### 7a — Write the SEC user-agent to config.json (only if Input A produced a value)
+
+Substitute the user's reply into this command and run it:
 
 ```bash
-service_doctor sec-indexer
+python3 -c "import json, pathlib; p = pathlib.Path('/home/workspace/clarion/config.json'); d = json.loads(p.read_text()); d['sec_user_agent'] = '<USER_INPUT_VERBATIM>'; p.write_text(json.dumps(d, indent=2))"
 ```
 
-**Expected:** `RUNNING` with a non-zero `uptime`. If the status shows `FATAL`, `BACKOFF`, `EXITED`, or `STOPPED`, the entrypoint failed to launch. The two failure modes you'll see in practice are:
+Replace `<USER_INPUT_VERBATIM>` with the user's exact reply (no quotes around it inside the Python string — the outer quotes are already there). Confirm the write by reading the file back and showing the `sec_user_agent` line.
 
-1. **Trailing characters in the entrypoint.** The registered `entrypoint` field should be exactly `sec-indexer`. If it's something like `sec-indexer</`, `sec-indexer\n`, or `ZO_API_KEY="$ZO_API_KEY" ... sec-indexer` (env vars inlined into the entrypoint string), the model output got corrupted during the tool call. The supervisor cannot execute these.
-2. **Missing or malformed env_vars.** If `ZO_API_KEY` or `CLARION_DATA_ROOT` aren't in the registered service's `env_vars` as separate keys (or got inlined into the entrypoint instead), the binary will either fail at startup (no token) or run but write to the wrong data root (`/root/clarion/` instead of `/home/workspace/clarion/`) — invisible to the user.
+### 7b — Restart the sec-indexer service
 
-Inspect logs if status is not RUNNING:
+Call `update_user_service` with the existing `sec-indexer` service_id and `action="restart"`. This:
+- Causes the supervisor to re-evaluate `$ZO_API_KEY` (now that the secret exists)
+- Restarts the `sec-indexer` process (which re-reads `config.json` on startup, picking up the new `sec_user_agent`)
+
+Confirm the restart command succeeded.
+
+## Step 8 — Verify the service is actually running (do not skip)
+
+Call the `service_doctor` agent tool:
+
+```
+service_doctor(service="sec-indexer")
+```
+
+**Expected:** status is `RUNNING` with non-zero `uptime`. The tool also reports listening status, source-file freshness, and suggests fixes for any detected issues.
+
+If the result shows `FATAL`, `BACKOFF`, `EXITED`, `STOPPED`, or any non-RUNNING state, the registration is genuinely broken. The two failure modes you'll see in practice:
+
+1. **Trailing characters in the entrypoint.** Check the registered service's `entrypoint` field via `list_user_services()`. It must be exactly `sec-indexer`. If it's something like `sec-indexer</`, `sec-indexer\n`, or has env vars inlined into the entrypoint shell-string, the model output got corrupted during the Step 3 tool call.
+2. **Missing or malformed env_vars.** If `ZO_API_KEY` or `CLARION_DATA_ROOT` aren't in the registered service's `env_vars` as separate keys, the binary will fail to authenticate or write to the wrong data root.
+
+Inspect logs via shell if needed:
 
 ```bash
 tail -50 /dev/shm/sec-indexer.log
 tail -50 /dev/shm/sec-indexer_err.log
 ```
 
-If anything is wrong, **delete the broken service and re-register**. Re-read this skill's *env_vars formatting* note from Step 4 first — the most common cause is `env_vars` being passed as a string instead of an object on the retry too.
-
-**Do not tell the user setup is complete until `service_doctor sec-indexer` shows RUNNING with non-zero uptime.** A registered-but-broken service is a worse failure mode than a registration that visibly failed.
+If anything is wrong, `delete_user_service` the broken one and re-do Step 3 — re-read the *env_vars formatting* guidance carefully. **Do not tell the user setup is complete until `service_doctor(service="sec-indexer")` reports RUNNING with non-zero uptime.**
 
 As a separate (weaker) sanity check that the binary is reachable on PATH:
 
@@ -126,7 +204,9 @@ As a separate (weaker) sanity check that the binary is reachable on PATH:
 sec-indexer --help
 ```
 
-This proves the executable resolves on PATH, but does NOT prove the service is running. The `service_doctor` check above is the one that actually validates the install.
+This proves the executable resolves on PATH, but does NOT prove the service is running. Step 8's `service_doctor` is the actual validation.
+
+## Step 9 — Report and explain
 
 Tell the user:
 
@@ -135,29 +215,34 @@ Tell the user:
 > - Source: `/home/workspace/clarion-intelligence-system/`
 > - Workspace data: the path printed in the `[2/6] Creating data tree under …` line from setup.py (typically `/home/workspace/clarion/` on Zo, `~/clarion/` on a local machine — auto-detected)
 > - Background service: `sec-indexer` (running)
-> - Skills installed under `/home/workspace/Skills/`: every sibling `clarion-*` skill from the repo (regime-check, sec-research, single-stock-eval, expected-return-calc, value-screener, thesis-write, thesis-monitor, watchlist-update, living-letter-update). List the actual names returned in the `[5/6] Installing sibling clarion-* skills ...` block from setup.py.
+> - Skills installed under `/home/workspace/Skills/`: every sibling `clarion-*` skill from setup.py's `[5/6]` block. List the actual names returned.
+> - Personas installed in Zo Settings → AI: the 7 Clarion personas you created in Step 4. List them by name (Data-First Plain Talk, Clarion Macro Sentinel, Clarion Value Screener, Clarion Analyst, Clarion Thesis Architect, Clarion Portfolio Manager, Clarion LP Voice).
+> - Rules installed in Zo Settings → AI: 8 Clarion rules (Rule 3 — live market data; Rules 5–10 — persona routing; Rule 11 — return to default).
+> - SEC EDGAR identification: `<the user's name and email from config.json>` (the actual value, not the placeholder).
 >
-> Just ask me things like *"what's the market regime?"*, *"analyze NVDA's latest 10-K"*, or *"is the market overvalued?"*.
+> Just ask me things like *"what's the market regime?"*, *"evaluate NVDA"*, *"update my watchlist"*, *"write a thesis on TTD"*, *"show me my portfolio"*, or *"update the Q1 letter"*.
+
+If anything in this report differs from the expected state (e.g., fewer than 7 personas, fewer than 8 rules, service not RUNNING, sec_user_agent is still the placeholder), call this out explicitly. Do not paper over partial-install state.
 
 ## Idempotency
 
 Re-running this skill is safe. Each step:
 
-- Repo clone: skipped if already cloned (just `git pull`)
-- Library install: re-runs `uv pip install -e` (no harm)
-- Data tree: `mkdir -p` (no harm)
-- Config: preserved if present
-- Skill install: each sibling `clarion-*` skill in `/home/workspace/Skills/` is refreshed (overwritten) with the upstream copy. This is the intended path to pull in upstream skill fixes after a `git pull`.
-- Service registration: if the user already has a `sec-indexer` service, `register_user_service` should report it exists; treat that as success.
+- **Repo clone**: skipped if already cloned (just `git pull --ff-only`)
+- **Library install**: re-runs `uv pip install -e` (no harm)
+- **Data tree**: `mkdir -p` (no harm)
+- **Config.json**: preserved if present — including any `sec_user_agent` the user previously set. The setup script does NOT overwrite an existing config.
+- **Skill install**: each sibling `clarion-*` skill in `/home/workspace/Skills/` is refreshed (overwritten) with the upstream copy. This is the intended path to pull in upstream skill fixes after a `git pull`.
+- **Service registration**: if the user already has a `sec-indexer` service, `register_user_service` should report it exists; treat that as success and continue.
+- **Persona install**: Step 4 calls `list_personas()` and asks the user before replacing any existing Clarion persona. User customizations are preserved unless the user opts in to replacement. The order is "ask first, then replace" — never silent overwrite.
+- **Rule install**: Same — Step 5 calls `list_rules()` and asks before replacing.
+- **Human checkpoint**: Step 6's Input A is skipped if `config.json` already has a non-placeholder `sec_user_agent`. Step 6's Input B is essentially "if the secret already exists, the user replies `done` immediately and the SKILL.md's USER_ACTION_REQUIRED message instructs them this is OK."
 
 ### Re-running to pick up source updates
 
 Editable installs (`uv pip install -e`) do NOT reload an already-running service — the `sec-indexer` process keeps the Python modules it imported at startup in memory. After a `git pull` brings in new code, you MUST restart the service for the changes to take effect.
 
-If the user is re-running setup specifically to pull in upstream fixes (or you see behavior matching code that no longer exists in the repo), restart the service after Step 4:
-
-- Use the `update_user_service` agent tool with the existing `sec-indexer` service ID and `action: restart` (or whatever the equivalent restart action is in the user's Zo environment).
-- Confirm the service comes back up before re-running any failed `clarion-sec-research` query.
+If the user is re-running setup specifically to pull in upstream fixes, the existing Step 7b restart in this flow handles this naturally. After Step 8 verifies RUNNING, the new code is live.
 
 ## On error
 
@@ -166,4 +251,7 @@ If any step fails, do not silently proceed. Read the error, summarize the cause,
 - **`gh: command not found`** — Zo should ship `gh`. If missing, the user's workspace is in a non-standard state; ask them to contact Zo support.
 - **`uv: command not found`** — same.
 - **`uv pip install` fails with venv error** — the script tries `--system` automatically; if it still fails, ask the user to share the full error.
-- **`register_user_service` fails** — surface the tool's error message; check whether `ZO_API_KEY` secret exists.
+- **`register_user_service` fails with a JSON-escaping or "runner stopped" error** — re-read the *env_vars formatting* guidance in Step 3. The most common cause is `env_vars` being passed as a stringified JSON instead of an object. Re-form the call and retry.
+- **`create_persona` / `create_rule` returns an error** — surface the error verbatim. Possible causes include a tool-not-available environment, malformed prompt text (check the extracted code block for stray markdown), or a transient platform error (retry once before giving up).
+- **`service_doctor` shows non-RUNNING after Step 7's restart** — follow the Step 8 troubleshooting (inspect entrypoint via `list_user_services()`, inspect logs, delete + re-register if entrypoint is corrupted). Do NOT mark setup complete.
+- **The user replies "no" to replacing personas/rules in Step 4/5** — that's their right. Continue with the existing persona's ID in the map for Step 5's rule substitutions. The final report in Step 9 should mention which personas/rules were preserved vs. created.


### PR DESCRIPTION
## What this changes

A brand-new Clarion install used to require **three user actions** — install the bootstrap skill, type *set up Clarion*, and (after that finished) paste a separate prompt for personas/rules into chat. Plus, an inline pause mid-flow to create the \`ZO_API_KEY\` secret. Plus, an undocumented silent failure (SEC EDGAR placeholder user-agent) that wasn't even surfaced to the user.

After this PR, the same install is **one chat prompt + one batched human checkpoint near the end**. The user types *set up Clarion*, the skill runs autonomously through clone → library → data tree → sibling skills → service registration → persona install → rule install, then asks for two inputs at once (SEC name+email AND the \`ZO_API_KEY\` secret), then resumes autonomously to restart the service, verify, and report.

## What unblocked this design

Per the Zo platform team's response to a tool-surface question (relayed in the conversation thread), the following agent tools exist and are reliable: \`create_persona\`, \`list_personas\`, \`delete_persona\`, \`create_rule\`, \`list_rules\`, \`delete_rule\`, \`service_doctor\`. Before that confirmation, persona/rule install had to be manual paste into Zo Settings; now it's an agent call.

## Files changed

| File | What |
|---|---|
| \`skills/clarion-setup/SKILL.md\` | Substantial reshape. New 9-step flow with persona/rule install as autonomous Steps 4-5, batched human checkpoint at Step 6 (with skip-if-already-set pre-check), config.json update + service restart at Step 7, service_doctor verification at Step 8, report at Step 9. \`env_vars\` formatting guidance from PR #20 preserved. service_doctor framed correctly as an agent tool (not a shell command — folding in the small correction). |
| \`README.md\` | Install section restructured. Old Step 4 (manual personas/rules paste) removed. Step 5 (Use it) renumbered to Step 4. Step 3 expanded to describe the batched human checkpoint (SEC name+email + ZO_API_KEY) clearly. Updating section drops the manual *restart the sec-indexer service* instruction since the flow handles it. |

## Re-run behavior (idempotency)

Step 6's pre-check makes a clean re-run fully autonomous:
- If \`~/clarion/config.json\` has a non-placeholder \`sec_user_agent\` AND \`service_doctor\` shows RUNNING, skip the human checkpoint entirely. Just restart and verify.
- If either condition fails (e.g., user is updating their SEC identification, or the service is broken), surface only the relevant input.

For personas/rules, Step 4 and Step 5 call \`list_*\` first and ask the user before replacing existing entries — preserves user customizations on re-run.

## The SEC user-agent fix (worth calling out)

This PR also closes a silent gap: previously, the default \`config.json\` shipped with \`sec_user_agent: \"Clarion Intelligence System (clarion@example.com)\"\` — a placeholder. Every Clarion install was hitting SEC EDGAR with that fingerprint, in violation of [SEC's fair-access policy](https://www.sec.gov/os/accessing-edgar-data) which asks every API consumer to identify themselves. Concentrating all Clarion users on one identifier is also a rate-limit risk.

Step 6 now prompts the user for their real name + email, the agent writes it to config.json, and \`sec-indexer\` picks it up on the Step 7b restart.

## Footprint

- 2 files changed: \`skills/clarion-setup/SKILL.md\` (+204/-87), \`README.md\` (+27/-49)
- No code changes. No new dependencies. 616 tests still pass.

## After merge

Sync to \`External/clarion-setup/SKILL.md\` in \`zocomputer/skills\` so new users installing via the registry get the new flow. Same two-PR pattern as PRs #79, #80, #81, #87. The manifest-regen bot will fire because the frontmatter description changed (mentioning persona/rule install now), so the registry catalog will also update.

## Out of scope for this PR

- Tests for the agent-driven persona/rule extraction from PERSONAS-AND-RULES.md. The extraction logic is in agent instructions, not Python — testable only via end-to-end install. We'll find out reliability empirically on the first re-install. If unreliable, a follow-up could add explicit markers in the doc (e.g., \`<!-- persona-prompt-start -->\`...\`<!-- persona-prompt-end -->\`) for deterministic extraction.
- The Zo support ticket items (env_vars schema clarity, runner-stopped timeouts) are still pending — separate concern, separate process.