### PR TITLE
docs: single-prompt install in README + full TEST-PLAN sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,50 +12,29 @@ Built around principles from Berkshire Hathaway and Buffett's annual letters, ad
 
 ## Install
 
-A brand-new Zo user gets fully set up in ~3-5 minutes. The entire install is two chat prompts and one batched human checkpoint near the end (your SEC EDGAR name+email and creating one Zo secret). Everything else — code, library, data tree, sibling skills, background service, personas, routing rules — is autonomous.
+A brand-new Zo user is fully set up in ~3-5 minutes.
 
-### 1. Install the bootstrap skill
+### Quick start
 
-In Zo chat:
+Paste this into Zo chat:
 
-> install the clarion-setup skill
+> Install the clarion-setup skill and set up Clarion.
 
-`clarion-setup` is the bootstrap — install this one **first** before any other `clarion-*` skill.
+That's the entire install. Zo handles everything — installs the bootstrap skill, clones the repo, installs the library, creates the workspace, registers the background service, installs all sibling skills, installs personas and routing rules — autonomously. It pauses **once** near the end for two inputs from you (your SEC EDGAR name+email AND creating the `ZO_API_KEY` Zo secret); everything else runs hands-off.
 
-### 2. Run the setup skill
+### What you'll be asked at the human checkpoint
 
-In Zo chat:
+When the skill pauses near the end, it surfaces **two things at once** — surface both together so you can multitask:
 
-> set up Clarion
-
-The skill runs autonomously through these steps:
-
-1. Clone this repo into `/home/workspace/clarion-intelligence-system`
-2. Install the `ai_buffett_zo` Python library (`uv pip install -e lib/`)
-3. Create the `~/clarion/` workspace tree (`data/`, `sec/`, `queue/`, `theses/`, `watchlists/`, `letters/`)
-4. Write `~/clarion/config.json` with sane model defaults (all Zo-hosted)
-5. Auto-install all nine sibling `clarion-*` skills under `/home/workspace/Skills/`
-6. Register the `sec-indexer` background service (will be in FATAL state until step 3 below — that's expected)
-7. Install all 7 Clarion personas in Zo Settings → AI → Personas
-8. Install the 8 Clarion routing rules (Rule 3 + Rules 5–11) in Zo Settings → AI → Rules
-
-Then it pauses for **one batched human checkpoint** — described in Step 3 below. After your input, the skill resumes autonomously: writes your SEC EDGAR identification to `~/clarion/config.json`, restarts the `sec-indexer` service, verifies it's running, and reports completion.
-
-Setup is idempotent — safe to re-run any time to pull source updates. It will ask before replacing any personas or rules you've customized.
-
-### 3. The one batched human checkpoint
-
-When the skill pauses, it asks for **two things at once** — surface them together so you can multitask:
-
-**(a) SEC EDGAR identification.** SEC requires every API consumer to identify itself in the User-Agent header. Type one line in chat:
+**(a) SEC EDGAR identification.** SEC requires every API consumer to identify itself in the User-Agent header. Type one line in chat when asked:
 
 ```
 Jane Doe jane@example.com
 ```
 
-(Your real name and email — sent in every SEC request from your machine. Only you and SEC see it. Required by SEC's [fair-access policy](https://www.sec.gov/os/accessing-edgar-data).)
+Your real name and email — sent in every SEC request from your machine. Only you and SEC see it. Required by [SEC's fair-access policy](https://www.sec.gov/os/accessing-edgar-data).
 
-**(b) Create the `ZO_API_KEY` secret in Zo Settings.** The `sec-indexer` background service needs a Zo-issued token to call Zo models on your behalf. Chat skills get a token auto-injected; background services don't, so you have to create one explicitly. The token is **Zo-issued** and bills against your Zo monthly credits — same pool as chat usage. **No external API keys involved.**
+**(b) Create the `ZO_API_KEY` secret in Zo Settings.** The `sec-indexer` background service needs a Zo-issued token to call Zo models on your behalf. Chat skills get a token auto-injected; background services don't, so you create one explicitly. **No external API keys** — the token is Zo-issued and bills against your Zo monthly credits.
 
 In a separate browser tab while you reply to (a):
 
@@ -66,13 +45,30 @@ In a separate browser tab while you reply to (a):
 5. **Value:** paste the token from step 2.
 6. Save.
 
-Once both are done — your SEC identification typed in chat AND the `ZO_API_KEY` secret created — reply `done`. The skill will write your SEC identification to config.json, restart `sec-indexer`, verify it's running, and report.
+Once both are done — SEC identification typed in chat AND `ZO_API_KEY` secret created — reply `done`. The skill writes your SEC identification to `~/clarion/config.json`, restarts the service, verifies it's running, and reports.
 
 That's the only manual config in the whole install.
 
-> **If Zo's chat agent didn't pause and ask you,** prompt it explicitly: *"walk me through the human checkpoint for Clarion setup — I need to provide my SEC EDGAR identification and create the ZO_API_KEY secret."* The full instructions live in the `clarion-setup` skill's SKILL.md — the agent should walk you through them.
+> **If Zo's chat agent didn't pause and ask you,** prompt it explicitly: *"walk me through the human checkpoint for Clarion setup — I need to provide my SEC EDGAR identification and create the ZO_API_KEY secret."* The full instructions live in the `clarion-setup` skill's SKILL.md.
 
-### 4. Use it conversationally
+### What the install does behind the scenes
+
+For reference — the Quick-start prompt above triggers all of this autonomously:
+
+1. Installs the `clarion-setup` bootstrap skill from the Zo registry
+2. Clones this repo into `/home/workspace/clarion-intelligence-system`
+3. Installs the `ai_buffett_zo` Python library (`uv pip install -e lib/`)
+4. Creates the `~/clarion/` workspace tree (`data/`, `sec/`, `queue/`, `theses/`, `watchlists/`, `letters/`) plus default `config.json`
+5. Auto-installs all nine sibling `clarion-*` skills under `/home/workspace/Skills/`
+6. Registers the `sec-indexer` background service (in FATAL state until the human checkpoint finishes — that's expected)
+7. Installs the 7 Clarion personas into Zo Settings → AI → Personas
+8. Installs 8 Clarion routing rules (Rule 3 + Rules 5–11) into Zo Settings → AI → Rules
+9. **Pauses for the human checkpoint** (see above)
+10. After your input: writes SEC identification to `config.json`, restarts `sec-indexer`, verifies via `service_doctor`, reports completion
+
+Setup is idempotent — safe to re-run. On a clean re-run (nothing customized, secret already exists, SEC identification already set), the human checkpoint is skipped entirely.
+
+### Use it conversationally
 
 That's it. Now ask Zo things like:
 
@@ -114,8 +110,8 @@ All 10 skills ship together. Install whichever you need:
 ## Requirements
 
 - A Zo Computer account (free tier works; subscriber tier unlocks higher-quality reasoning models)
-- `clarion-setup` run **once** before any other `clarion-*` skill (it registers the `sec-indexer` background service every other skill depends on)
-- A Zo access token (Settings → Advanced → Access Tokens), saved as a secret named `ZO_API_KEY` (Settings → Advanced → Secrets) — used by the SEC indexer to call models on your behalf, billed against your Zo credits
+- A Zo access token, created **during install** at the human checkpoint described above — used by the SEC indexer to call models on your behalf, billed against your Zo credits
+- A name and email for SEC EDGAR identification (provided during install) — public to SEC only
 - ~100 GB workspace headroom is plenty even for a 50-ticker watchlist
 
 No external API keys. No broker accounts. No real-time data feeds.

--- a/docs/TEST-PLAN.md
+++ b/docs/TEST-PLAN.md
@@ -14,55 +14,64 @@ For each test, record: Pass / Fail / Skipped + a one-line output excerpt or erro
 
 **Goal:** prove the system installs, the service runs, and the simplest end-to-end query works.
 
-### T1.1 — Install bootstrap skill
+### T1.1 — Single-prompt install
 
-**Prompt:** `install the clarion-setup skill`
+**Prompt:** `Install the clarion-setup skill and set up Clarion.`
 
-**Pass:** Zo confirms install.
+**Pass:** Zo installs the bootstrap skill from the registry, then invokes it. The skill runs autonomously through: clone source repo → install lib → create workspace tree → write placeholder `config.json` → auto-install nine sibling `clarion-*` skills → register `sec-indexer` service (will be in FATAL state, expected) → install 7 Clarion personas → install 8 Clarion routing rules (Rule 3 + Rules 5–11). Then pauses for the batched human checkpoint described in T1.2.
 
-### T1.2 — Run setup
+### T1.2 — Batched human checkpoint
 
-**Prompt:** `set up Clarion`
+When the skill pauses, it surfaces two asks together:
 
-**Pass:** Zo invokes `clarion-setup`. Clones the source repo into `/home/workspace/clarion-intelligence-system`, installs the lib, creates the workspace tree, then pauses to ask for the `ZO_API_KEY` secret.
+**(a) SEC EDGAR identification.** Type one line in chat in the format:
 
-### T1.3 — Create the `ZO_API_KEY` secret
+```
+Jane Doe jane@example.com
+```
 
-Follow the prompt:
+(Your real name and email — sent to SEC in every API request.)
+
+**(b) `ZO_API_KEY` secret.** In Zo Settings (separate browser tab):
 
 1. Settings → Advanced → Access Tokens → create a new token (any name). Copy the value.
 2. Settings → Advanced → Secrets → create a secret named **exactly** `ZO_API_KEY` with the token as the value.
-3. Tell Zo "done".
+3. Once both (a) and (b) are done, reply `done` in chat.
 
-**Pass:** Zo calls `register_user_service`, reports a service ID, and prints `SETUP_RESULT: ok`.
+**Pass:** Zo writes your SEC identification to `~/clarion/config.json`, restarts `sec-indexer` via `update_user_service`, and calls `service_doctor(service="sec-indexer")` showing **RUNNING with non-zero uptime**. Reports a service ID and completion.
 
-### T1.4 — Verify the workspace
+### T1.3 — Verify the workspace
 
 **Prompt:** `ls ~/clarion`
 
-**Pass:** Subdirs `data/equities`, `sec`, `queue`, `theses`, `watchlists`, `letters`, plus `config.json`.
+**Pass:** Subdirs `data/equities`, `sec`, `queue`, `theses`, `watchlists`, `letters`, plus `config.json`. Check `cat ~/clarion/config.json | grep sec_user_agent` — should be your real name+email, NOT the placeholder `clarion@example.com`.
 
-### T1.5 — Regime check (no SEC indexing required)
-
-**Prompts:**
-
-1. `install the clarion-regime-check skill`
-2. `what's the market regime?`
-
-**Pass:** Returns SPY/TLT/RSP color and the equity hurdle rate. Fast (no indexing). Proves the chat-skill auto-token path works without `ZO_API_KEY` in scope (chat skills get `ZO_CLIENT_IDENTITY_TOKEN` auto-injected; only the `sec-indexer` service needs `ZO_API_KEY`).
-
-### T1.6 — SEC research happy path
+### T1.4 — Verify personas and rules were installed
 
 **Prompts:**
 
-1. `install the clarion-sec-research skill`
-2. `index NVDA's latest 10-K`
-3. *(wait 1-5 min)* `status NVDA`
-4. *(once `status` shows completed)* `what does NVDA say about Blackwell?`
+1. *(via agent tool)* `list_personas()` — should return at least the 7 Clarion personas (Data-First Plain Talk, Clarion Macro Sentinel, Clarion Value Screener, Clarion Analyst, Clarion Thesis Architect, Clarion Portfolio Manager, Clarion LP Voice).
+2. *(via agent tool)* `list_rules()` — should return at least 8 Clarion rules (Rule 3 — live market data, Rules 5–11 — routing + return-to-default).
 
-**Pass:** Indexing completes. Search returns a hit table + top-5 snippets. Every snippet has a canonical citation: `NVDA 10-K filed YYYY-MM-DD → section`.
+**Pass:** All 7 Clarion personas and 8 Clarion rules present. Names match the doc.
 
-**Tier 1 passes if T1.1-T1.6 all worked without intervention beyond the `ZO_API_KEY` creation step.**
+### T1.5 — Regime check (auto-routes to Macro Sentinel persona)
+
+**Prompt:** `what's the market regime?`
+
+**Pass:** Rule 6 routes to the Clarion Macro Sentinel persona (verify by checking which persona answered, or by output style — terse, regime-first, hurdle-rate framing). Returns SPY/TLT/RSP color and the equity hurdle rate. Fast (no indexing). Proves the chat-skill auto-token path works without `ZO_API_KEY` in scope (chat skills get `ZO_CLIENT_IDENTITY_TOKEN` auto-injected; only the `sec-indexer` service needs `ZO_API_KEY`).
+
+### T1.6 — SEC research happy path (auto-routes to Analyst when appropriate)
+
+**Prompts:**
+
+1. `index NVDA's latest 10-K`
+2. *(wait 1-5 min)* `status NVDA`
+3. *(once `status` shows completed)* `what does NVDA say about Blackwell?`
+
+**Pass:** Indexing completes. Search returns a hit table + top-5 snippets. Every snippet has a canonical citation: `NVDA 10-K filed YYYY-MM-DD → section`. *(`clarion-sec-research` is auto-installed by setup — no separate install step needed.)*
+
+**Tier 1 passes if T1.1-T1.6 all worked with the single install prompt and one batched human checkpoint.**
 
 ## Tier 2 — Full functional coverage
 
@@ -134,6 +143,17 @@ Follow the prompt:
 
 **This is the test that proves the skill descriptions correctly express their dependencies and the router can string them together autonomously.**
 
+### T2.10 — Portfolio monitor (operator-personal; skip if TastyTrade not configured)
+
+**Prompts:**
+
+1. `show me my portfolio`
+2. `what's my NLV history over the last 30 days?`
+
+**Pass:** Rule 7 routes to the Portfolio Manager persona. If TastyTrade credentials (`TASTYTRADE_CLIENT_SECRET`, `TASTYTRADE_REFRESH_TOKEN`) are configured as Zo secrets: `fetch.py` returns a JSON+Markdown snapshot under `~/clarion/portfolio/YYYY-MM-DD.{json,md}`; `query.py` queries the DuckDB at `~/clarion/portfolio/portfolio.duckdb` and returns NLV history.
+
+**Skip if TastyTrade not configured.** The `clarion-portfolio-monitor` skill is operator-personal (TastyTrade-only) — the persona instructions for Step 0.1/0.2 will surface a clear "secrets not set" error if the user invokes them without credentials. Confirming that error path is itself a valid pass for an operator not using TastyTrade.
+
 ## Tier 3 — Stress and regression
 
 **Goal:** prove robustness against edge cases, error paths, and previously-fixed bugs.
@@ -150,11 +170,19 @@ Follow the prompt:
 
 **Pass:** Returns no hits and suggests indexing first. Does NOT fabricate from training data.
 
-### T3.3 — Re-run setup (idempotency + service-restart reminder)
+### T3.3 — Re-run setup (full idempotency, autonomous restart, human checkpoint skip)
 
 **Prompt:** `set up Clarion again`
 
-**Pass:** All steps idempotent. Setup output explicitly tells Zo to restart `sec-indexer`. **This is the verification for the operator-doc patch:** editable `uv pip install -e` does NOT reload an already-running service, so the reminder must fire.
+**Pass:**
+
+- All Step 1–5 actions are idempotent (clone is `git pull --ff-only`; lib re-install is no-op; data tree `mkdir -p`; existing personas/rules not silently replaced).
+- Step 4 (persona install) and Step 5 (rule install) call `list_personas()` / `list_rules()` first, find the existing Clarion entries, and **ask the user** before replacing. Answer "no" — verify nothing is replaced.
+- Step 6 (human checkpoint) is **fully skipped** on a clean re-run — both pre-checks pass (`sec_user_agent` is non-placeholder, `service_doctor` shows RUNNING).
+- Step 7b automatically restarts `sec-indexer` so any updated lib code (from the `git pull`) is loaded into the running process. No separate "restart the service" command needed.
+- Step 8 verifies `service_doctor(service="sec-indexer")` shows RUNNING with non-zero uptime post-restart.
+
+**This is the verification for the auto-restart and skip-checkpoint patches:** editable `uv pip install -e` doesn't reload an already-running service, so the restart must fire automatically in Step 7b; and re-running with everything already configured should not re-prompt the user for inputs already on file.
 
 ### T3.4 — Service restart
 
@@ -247,4 +275,4 @@ Update this test plan when:
 - A bug is found in production → add a Tier 3 regression case so it can't return silently
 - A skill's description changes → update the routing tests in Tier 3
 
-Source: `github.com/jingerzz/clarion-intelligence-system`. Last reviewed against commit `49ccaff` (2026-05-08), with the T3.11 form-match regression case added after the live Tier 3 stress test surfaced the `DEF14A != DEF 14A` bug.
+Source: `github.com/jingerzz/clarion-intelligence-system`. Last reviewed against commit `7430985` (2026-05-19), updated to reflect the single-prompt install flow (PR #21), the SEC user-agent fix, the persona/rule auto-install path (PR #21 + Zo platform agent tools), and the post-PR #20 service-startup verification via `service_doctor`. T2.10 added for the operator-personal `clarion-portfolio-monitor` skill (PR #15).


### PR DESCRIPTION
Two coordinated docs updates responding to an audit.

## README — single-prompt install surfaced

Before this PR, the README's Install section had two separate prompts (\"install the clarion-setup skill\" then \"set up Clarion\") plus an inline pause for the ZO_API_KEY secret. After this PR, the **Quick start** at the top of the Install section surfaces one prompt:

> Install the clarion-setup skill and set up Clarion.

The detailed structure below the Quick start is reorganized **action-first**:
1. Quick start (the one prompt)
2. What you'll be asked at the human checkpoint (so users can prepare both inputs before they're asked)
3. What the install does behind the scenes (FYI, the 10-step autonomous chain)
4. Use it conversationally

Two small fixes along the way:
- Step 3 (a) used to read \"Type one line in chat\" imperatively, like the user should type it immediately. Now reads \"Type one line in chat when asked\" — the user waits for the prompt.
- Requirements section's standalone ZO_API_KEY bullet (redundant with Install's human checkpoint) is gone. SEC EDGAR identification added as an explicit prerequisite since the install now asks for it.

## TEST-PLAN.md — full sweep across all three tiers

Stale references replaced:
- **T1.1** collapsed to the single install prompt; Pass criteria enumerates the full autonomous chain.
- **T1.2** renamed to \"Batched human checkpoint\" — covers SEC name+email AND ZO_API_KEY together. Pass requires service_doctor RUNNING.
- **T1.4** new — explicit persona/rule install verification via list_personas() and list_rules() (the new install path makes these autonomous, so they need verification).
- **T1.5 / T1.6** drop the \"install the clarion-X skill\" steps — sibling skills auto-installed by clarion-setup. T1.5 also notes Rule 6 routing.
- **T2.10** new — operator-personal clarion-portfolio-monitor skill from PR #15, with explicit skip-if-not-configured guidance.
- **T3.3** expanded for the new idempotency contract: ask-before-replace on personas/rules, autonomous restart in Step 7b, full skip of human checkpoint on a clean re-run.
- Maintenance footer updated: \`Last reviewed against commit 7430985 (2026-05-19)\`, with explicit list of which recent PRs were folded in.

Tier 2 (T2.1-T2.9) and the Tier 3 routing/regression tests (T3.5-T3.12) were checked for staleness — none found. They describe behaviors that haven't changed since the May 8 reference point.

## Footprint

- 2 files: \`README.md\` (+27/-39), \`docs/TEST-PLAN.md\` (+59/-23)
- 616 tests still pass

## After merge

No Zo Skills registry sync needed — both files are source-only docs. No need for upgrade prompts to existing Zo Computers either — the README/TEST-PLAN aren't installed on user machines.