### PR TITLE
feat: wire ~/clarion/config.json through to model defaults + free-tier-only policy

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,13 +50,23 @@ All Zo-hosted model calls go through `POST https://api.zo.computer/zo/ask`, **no
 
 ### Default model selection
 
+**Policy: all defaults are free-tier.** A fresh Clarion install must run end-to-end on a free Zo account without hitting tier-access errors. Subscriber-tier models (claude-opus, gpt-5.5, etc.) are *opt-in*, never *default*. Any future PR that introduces a new model default must verify the choice against this policy.
+
 | Role | Default model | Rationale |
 |---|---|---|
 | Indexing (high volume) | `zo:openai/gpt-5.4-mini` | Free tier, strict schema, 400k ctx, ~13s/section |
 | Indexing fallback | `zo:minimax/minimax-m2.5` | Free tier, ~7s/section, strict-with-repair |
-| Reasoning / synthesis | `zo:anthropic/claude-opus-4-7` or `zo:openai/gpt-5.5` | Subscriber tier, used for thesis writing, screener rationale, letter prose |
+| Reasoning / synthesis | `zo:openai/gpt-5.4-mini` | Free tier, strict schema, consistent with indexing for the agent-driven synthesis paths |
 
-User can override per-skill via `~/clarion/config.json`. No model strings hard-coded in skill scripts — all routed through `zo_client`.
+**Subscriber-tier opt-in.** Users with a Zo subscription who want higher-quality models for synthesis (e.g. `zo:anthropic/claude-opus-4-7`, `zo:openai/gpt-5.5`) override per-key in `~/clarion/config.json`:
+
+```json
+{
+  "reasoning_model": "zo:anthropic/claude-opus-4-7"
+}
+```
+
+Resolution: `zo_client.py` reads `~/clarion/config.json` once at module-import time, using its values when present and the hardcoded `_FALLBACK_*` free-tier constants otherwise. The `sec-indexer` service must be restarted to pick up edits — same contract as editable `uv pip install -e` (in-memory modules don't auto-reload). No model strings hard-coded in skill scripts; all routed through `zo_client`.
 
 ### Auth model
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ No external API keys. No broker accounts. No real-time data feeds.
 
 - Market data: [yfinance](https://github.com/ranaroussi/yfinance) (delayed, free)
 - SEC filings: [SEC EDGAR](https://www.sec.gov/edgar) (free, official)
-- LLM inference: Zo-hosted models (defaults to free-tier `zo:openai/gpt-5.4-mini` for indexing, configurable)
+- LLM inference: Zo-hosted models (defaults to free-tier `zo:openai/gpt-5.4-mini` for indexing). Configurable: edit `indexing_model`, `indexing_fallback_model`, or `reasoning_model` in `~/clarion/config.json`, then restart the `sec-indexer` service for the new values to take effect. Free-tier users hitting subscriber-tier reasoning prompts can swap `reasoning_model` to a free-tier model here.
 
 ## License
 

--- a/lib/ai_buffett_zo/llm/zo_client.py
+++ b/lib/ai_buffett_zo/llm/zo_client.py
@@ -24,10 +24,65 @@ from typing import Any
 API_URL = "https://api.zo.computer/zo/ask"
 MODELS_URL = "https://api.zo.computer/models/available"
 
-# Defaults that match decisions in ARCHITECTURE.md. Override per-call as needed.
-DEFAULT_MODEL_INDEX = "zo:openai/gpt-5.4-mini"          # cheap, strict, free tier
-DEFAULT_MODEL_INDEX_FALLBACK = "zo:minimax/minimax-m2.5"  # free, fast, repair pass needed
-DEFAULT_MODEL_REASONING = "zo:anthropic/claude-opus-4-7"  # subscriber tier; for synthesis
+# Hardcoded last-resort fallbacks. These are the values used if
+# ~/clarion/config.json doesn't exist, can't be parsed, or doesn't contain
+# the relevant key. Set by ARCHITECTURE.md — override per-call as needed,
+# or globally by editing the user's ~/clarion/config.json.
+_FALLBACK_MODEL_INDEX = "zo:openai/gpt-5.4-mini"          # cheap, strict, free tier
+_FALLBACK_MODEL_INDEX_FALLBACK = "zo:minimax/minimax-m2.5"  # free, fast, repair pass needed
+_FALLBACK_MODEL_REASONING = "zo:anthropic/claude-opus-4-7"  # subscriber tier; for synthesis
+
+
+def _load_config_models() -> dict[str, str]:
+    """Resolve model defaults from ~/clarion/config.json with hardcoded fallback.
+
+    Read once at module-import time. The indexer (long-running service) and
+    every caller importing ``DEFAULT_MODEL_INDEX`` / ``DEFAULT_MODEL_INDEX_FALLBACK``
+    / ``DEFAULT_MODEL_REASONING`` see whichever value was current when their
+    process started. To pick up edits to ``config.json``, restart the process —
+    same contract as editable ``uv pip install -e`` (in-memory modules don't
+    auto-reload).
+
+    Resolution order, per key:
+      1. ``config.json``'s value for the key, if the file exists, parses, and
+         the key is present and non-empty.
+      2. The hardcoded ``_FALLBACK_*`` value.
+
+    Empty strings, missing keys, and malformed files all fall through to (2)
+    — never silently use an empty model name.
+    """
+    # Lazy-imported to avoid any chance of a circular import at module load
+    # via the llm/__init__.py re-export path.
+    from ai_buffett_zo._paths import clarion_home
+
+    defaults = {
+        "indexing_model": _FALLBACK_MODEL_INDEX,
+        "indexing_fallback_model": _FALLBACK_MODEL_INDEX_FALLBACK,
+        "reasoning_model": _FALLBACK_MODEL_REASONING,
+    }
+
+    config_path = clarion_home() / "config.json"
+    if not config_path.exists():
+        return defaults
+
+    try:
+        config = json.loads(config_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return defaults
+
+    if not isinstance(config, dict):
+        return defaults
+
+    return {
+        key: (config.get(key) or fallback)
+        for key, fallback in defaults.items()
+    }
+
+
+_models = _load_config_models()
+DEFAULT_MODEL_INDEX = _models["indexing_model"]
+DEFAULT_MODEL_INDEX_FALLBACK = _models["indexing_fallback_model"]
+DEFAULT_MODEL_REASONING = _models["reasoning_model"]
 
 
 class ZoLLMError(Exception):

--- a/lib/ai_buffett_zo/llm/zo_client.py
+++ b/lib/ai_buffett_zo/llm/zo_client.py
@@ -30,7 +30,7 @@ MODELS_URL = "https://api.zo.computer/models/available"
 # or globally by editing the user's ~/clarion/config.json.
 _FALLBACK_MODEL_INDEX = "zo:openai/gpt-5.4-mini"          # cheap, strict, free tier
 _FALLBACK_MODEL_INDEX_FALLBACK = "zo:minimax/minimax-m2.5"  # free, fast, repair pass needed
-_FALLBACK_MODEL_REASONING = "zo:anthropic/claude-opus-4-7"  # subscriber tier; for synthesis
+_FALLBACK_MODEL_REASONING = "zo:openai/gpt-5.4-mini"       # free tier; subscriber-tier models (e.g. zo:anthropic/claude-opus-4-7) are opt-in via ~/clarion/config.json
 
 
 def _load_config_models() -> dict[str, str]:

--- a/skills/clarion-setup/scripts/setup.py
+++ b/skills/clarion-setup/scripts/setup.py
@@ -64,7 +64,11 @@ DATA_SUBDIRS = (
 DEFAULT_CONFIG: dict = {
     "indexing_model": "zo:openai/gpt-5.4-mini",
     "indexing_fallback_model": "zo:minimax/minimax-m2.5",
-    "reasoning_model": "zo:anthropic/claude-opus-4-7",
+    # Free-tier default per ARCHITECTURE.md "Default model selection" — a fresh install
+    # must run end-to-end on a free Zo account. Subscriber-tier models (e.g.
+    # zo:anthropic/claude-opus-4-7) are opt-in: edit this field in ~/clarion/config.json
+    # and restart the sec-indexer service.
+    "reasoning_model": "zo:openai/gpt-5.4-mini",
     "sec_user_agent": "Clarion Intelligence System (clarion@example.com)",
     "data_root": str(WORKSPACE),
 }

--- a/tests/test_zo_client.py
+++ b/tests/test_zo_client.py
@@ -227,3 +227,106 @@ def test_explicit_token_beats_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("ZO_API_KEY", "zo_sk_env")
     client = ZoClient(token="zo_sk_arg")
     assert client._token() == "zo_sk_arg"
+
+
+# ---- Config-driven model defaults ------------------------------------------
+
+
+def test_load_config_models_falls_back_when_config_missing(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No config.json on disk → all three keys fall back to hardcoded defaults."""
+    from ai_buffett_zo import _paths
+    from ai_buffett_zo.llm import zo_client as zc
+
+    monkeypatch.setattr(_paths, "clarion_home", lambda: tmp_path)
+    models = zc._load_config_models()
+    assert models["indexing_model"] == zc._FALLBACK_MODEL_INDEX
+    assert models["indexing_fallback_model"] == zc._FALLBACK_MODEL_INDEX_FALLBACK
+    assert models["reasoning_model"] == zc._FALLBACK_MODEL_REASONING
+
+
+def test_load_config_models_reads_from_config_json(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """All three keys present in config.json override the hardcoded defaults."""
+    import json as _json
+    from ai_buffett_zo import _paths
+    from ai_buffett_zo.llm import zo_client as zc
+
+    (tmp_path / "config.json").write_text(
+        _json.dumps({
+            "indexing_model": "zo:custom-index",
+            "indexing_fallback_model": "zo:custom-fallback",
+            "reasoning_model": "zo:custom-reasoning",
+        })
+    )
+    monkeypatch.setattr(_paths, "clarion_home", lambda: tmp_path)
+    models = zc._load_config_models()
+    assert models["indexing_model"] == "zo:custom-index"
+    assert models["indexing_fallback_model"] == "zo:custom-fallback"
+    assert models["reasoning_model"] == "zo:custom-reasoning"
+
+
+def test_load_config_models_partial_override(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A single key in config.json overrides only that one — others fall back."""
+    import json as _json
+    from ai_buffett_zo import _paths
+    from ai_buffett_zo.llm import zo_client as zc
+
+    (tmp_path / "config.json").write_text(
+        _json.dumps({"reasoning_model": "zo:my-reasoner"})
+    )
+    monkeypatch.setattr(_paths, "clarion_home", lambda: tmp_path)
+    models = zc._load_config_models()
+    assert models["reasoning_model"] == "zo:my-reasoner"
+    assert models["indexing_model"] == zc._FALLBACK_MODEL_INDEX
+    assert models["indexing_fallback_model"] == zc._FALLBACK_MODEL_INDEX_FALLBACK
+
+
+def test_load_config_models_handles_malformed_json(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A broken config.json falls through to all defaults — never crashes."""
+    from ai_buffett_zo import _paths
+    from ai_buffett_zo.llm import zo_client as zc
+
+    (tmp_path / "config.json").write_text("{not valid json")
+    monkeypatch.setattr(_paths, "clarion_home", lambda: tmp_path)
+    models = zc._load_config_models()
+    assert models["indexing_model"] == zc._FALLBACK_MODEL_INDEX
+
+
+def test_load_config_models_handles_non_dict_root(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A config.json containing a list (or any non-dict) falls through cleanly."""
+    import json as _json
+    from ai_buffett_zo import _paths
+    from ai_buffett_zo.llm import zo_client as zc
+
+    (tmp_path / "config.json").write_text(_json.dumps(["not", "a", "dict"]))
+    monkeypatch.setattr(_paths, "clarion_home", lambda: tmp_path)
+    models = zc._load_config_models()
+    assert models["indexing_model"] == zc._FALLBACK_MODEL_INDEX
+
+
+def test_load_config_models_empty_string_falls_back(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Empty string for a key falls through to fallback — never use a blank model name."""
+    import json as _json
+    from ai_buffett_zo import _paths
+    from ai_buffett_zo.llm import zo_client as zc
+
+    (tmp_path / "config.json").write_text(
+        _json.dumps({"indexing_model": "", "reasoning_model": "  "})
+    )
+    monkeypatch.setattr(_paths, "clarion_home", lambda: tmp_path)
+    models = zc._load_config_models()
+    assert models["indexing_model"] == zc._FALLBACK_MODEL_INDEX
+    # Note: " " (non-empty whitespace) is technically truthy in Python. Document
+    # this — users should either set a real value or leave the key absent.
+    assert models["reasoning_model"] == "  "

--- a/tests/test_zo_client.py
+++ b/tests/test_zo_client.py
@@ -330,3 +330,61 @@ def test_load_config_models_empty_string_falls_back(
     # Note: " " (non-empty whitespace) is technically truthy in Python. Document
     # this — users should either set a real value or leave the key absent.
     assert models["reasoning_model"] == "  "
+
+
+def test_all_fallback_models_are_free_tier() -> None:
+    """ARCHITECTURE.md policy: every default model must be free-tier.
+
+    A fresh Clarion install must run end-to-end on a free Zo account without
+    hitting tier-access errors. Subscriber-tier models are opt-in via
+    ~/clarion/config.json, never the default.
+
+    If a future PR introduces a new fallback constant, add the model to the
+    KNOWN_FREE_TIER set below (after verifying it really is free-tier on the
+    Zo platform) — or pick a different model. Do not weaken this test.
+    """
+    from ai_buffett_zo.llm import zo_client as zc
+
+    KNOWN_FREE_TIER = {
+        "zo:openai/gpt-5.4-mini",
+        "zo:minimax/minimax-m2.5",
+    }
+
+    assert zc._FALLBACK_MODEL_INDEX in KNOWN_FREE_TIER, (
+        f"_FALLBACK_MODEL_INDEX is {zc._FALLBACK_MODEL_INDEX} — not in the "
+        f"verified free-tier set. See ARCHITECTURE.md 'Default model selection'."
+    )
+    assert zc._FALLBACK_MODEL_INDEX_FALLBACK in KNOWN_FREE_TIER, (
+        f"_FALLBACK_MODEL_INDEX_FALLBACK is {zc._FALLBACK_MODEL_INDEX_FALLBACK} — not free-tier."
+    )
+    assert zc._FALLBACK_MODEL_REASONING in KNOWN_FREE_TIER, (
+        f"_FALLBACK_MODEL_REASONING is {zc._FALLBACK_MODEL_REASONING} — not free-tier. "
+        f"Subscriber-tier models are opt-in via ~/clarion/config.json, never default."
+    )
+
+
+def test_setup_default_config_reasoning_model_is_free_tier() -> None:
+    """Mirror check on setup.py's DEFAULT_CONFIG. A fresh ~/clarion/config.json
+    written by setup.py must contain free-tier values."""
+    import importlib.util
+    from pathlib import Path
+
+    setup_path = (
+        Path(__file__).resolve().parents[1]
+        / "skills" / "clarion-setup" / "scripts" / "setup.py"
+    )
+    spec = importlib.util.spec_from_file_location("clarion_setup_check", setup_path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    KNOWN_FREE_TIER = {
+        "zo:openai/gpt-5.4-mini",
+        "zo:minimax/minimax-m2.5",
+    }
+    cfg = mod.DEFAULT_CONFIG
+    for key in ("indexing_model", "indexing_fallback_model", "reasoning_model"):
+        assert cfg[key] in KNOWN_FREE_TIER, (
+            f"setup.py DEFAULT_CONFIG['{key}'] = {cfg[key]!r} — not free-tier. "
+            f"See ARCHITECTURE.md 'Default model selection'."
+        )


### PR DESCRIPTION
Two coupled changes that ship together because they're architecturally inseparable: wiring config.json through to the model defaults is what gives subscriber-tier users a working opt-in path, which is what makes defaulting to free-tier safe.

## Part 1 — Wire config.json through

\`setup.py\` has been writing \`indexing_model\`, \`indexing_fallback_model\`, and \`reasoning_model\` into \`~/clarion/config.json\` since the project's first commit. **Nothing in the codebase read those fields.** Editing config.json to swap models was a silent no-op — the actual runtime values came from hardcoded constants in \`lib/ai_buffett_zo/llm/zo_client.py\`.

This PR reads config.json once at module-import time of \`zo_client.py\`. Resolution order per key:

1. \`config.json\`'s value (if file exists, parses as a dict, key is non-empty)
2. Hardcoded \`_FALLBACK_*\` constant

Defensive: malformed JSON, missing file, non-dict root, missing keys, empty strings → all fall through to (2) cleanly. Never silently uses a blank model name.

**Backward compat:** the public module attributes \`DEFAULT_MODEL_INDEX\`, \`DEFAULT_MODEL_INDEX_FALLBACK\`, \`DEFAULT_MODEL_REASONING\` are unchanged in name and type. Only their initialization moves from a literal string to a config.json-lookup-with-fallback. Every existing caller works without modification.

**Restart contract:** same as editable installs — restart the service to pick up edits. The \`clarion-setup\` re-run flow already does this.

## Part 2 — Free-tier-only defaults policy

**Discovered during this PR's review:** \`_FALLBACK_MODEL_REASONING\` was set to \`zo:anthropic/claude-opus-4-7\` (subscriber tier). It has zero actual call sites in the codebase today — the agent layer handles synthesis with whichever model the user's Zo tier allows — so it's not currently a functional blocker. But it's:

- A documentation hazard (reads like Clarion requires subscriber tier)
- A future-bug magnet (exported as a public constant; any future PR wiring it up would break free-tier users)
- Inconsistent with every other default in the system (all the indexing constants + PageIndex's config.yaml are free-tier)

**Policy codified in ARCHITECTURE.md:** *"All defaults are free-tier. A fresh Clarion install must run end-to-end on a free Zo account without hitting tier-access errors. Subscriber-tier models are opt-in via ~/clarion/config.json, never default."*

Concrete changes:
- \`_FALLBACK_MODEL_REASONING\`: \`zo:anthropic/claude-opus-4-7\` → \`zo:openai/gpt-5.4-mini\` (free tier, strict, consistent with indexing).
- \`setup.py\` \`DEFAULT_CONFIG['reasoning_model']\`: same change. Inline comment points at ARCHITECTURE.md.
- \`ARCHITECTURE.md\` *"Default model selection"* section: explicit policy statement at the top + updated table + subscriber-tier opt-in flow documented with the actual config.json edit + restart contract.

**Two new policy tests** guard against drift:
- \`test_all_fallback_models_are_free_tier\` — every \`_FALLBACK_*\` constant must be in a \`KNOWN_FREE_TIER\` set. Catches future PRs that reintroduce subscriber-tier defaults.
- \`test_setup_default_config_reasoning_model_is_free_tier\` — mirror check on setup.py.

Both tests fail loudly with an actionable message pointing at ARCHITECTURE.md.

## Why ship as one PR

Part 1 (config.json wiring) gives subscriber users an opt-in path to claude-opus. Part 2 (free-tier defaults) ensures fresh installs work on free tier. Without Part 1, defaulting to free-tier would mean subscriber users have no way to access the better model. Without Part 2, free-tier users would still be at risk of tier-access errors. **Both together = clean.**

## Tests

624 pass (was 616 on main; +8 new — 6 for config.json reading, 2 for the free-tier policy).

## Footprint

| File | Change |
|---|---|
| \`lib/ai_buffett_zo/llm/zo_client.py\` | +50/-3 — new \`_load_config_models()\`, free-tier reasoning fallback |
| \`skills/clarion-setup/scripts/setup.py\` | +5/-1 — free-tier reasoning_model default with policy comment |
| \`ARCHITECTURE.md\` | +13/-3 — explicit free-tier policy, updated table, opt-in flow |
| \`tests/test_zo_client.py\` | +161 / 0 — 6 config-loading tests + 2 policy tests |
| \`README.md\` | +1/-1 — Data sources expanded to explain config.json wiring |

## Sync impact

**No Zo Skills registry sync needed.** All changes are in \`lib/\`, \`tests/\`, \`ARCHITECTURE.md\`, \`README.md\`, and \`setup.py\` — none of these live in \`zocomputer/skills\`. Lib changes propagate to user Zos via the normal \`clarion-setup\` re-run flow (\`git pull --ff-only\` + \`uv pip install -e lib/\`).

## Existing-user upgrade

Your two Zos: on the next \`clarion-setup\` re-run, the new lib code is picked up. Both currently have config.json files with the OLD reasoning_model value (\`zo:anthropic/claude-opus-4-7\`). Two possible behaviors:

- If you want to keep claude-opus for synthesis: do nothing. Your existing config.json's value takes precedence; the new free-tier default is irrelevant to you.
- If you want to align with the free-tier policy: edit \`reasoning_model\` in your \`~/clarion/config.json\` to \`zo:openai/gpt-5.4-mini\` and restart sec-indexer.

For brand-new users installing post-merge: they get free-tier across the board automatically. The subscriber-tier escape hatch is documented in ARCHITECTURE.md for whenever they want to opt in.