### PR TITLE
docs: move persona/rule install out of clarion-setup autonomous path

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -23,6 +23,15 @@ Published via the **External path** of [`zocomputer/skills`](https://github.com/
 
 Users install with chat commands like `install the clarion-setup skill`. Zo curls `manifest.json`, untars the slug folder into the user's `~/Skills/`. No `gh clone` required from the user side.
 
+### Install scope: skills + service, not personas
+
+`clarion-setup` installs the **functional layer** (library, sibling skills, sec-indexer service) and stops. Personas and routing rules are **not** in the autonomous install path — they're a separate, opt-in step the user triggers via *"install Clarion personas and routing rules"* after the bare install completes. Two reasons:
+
+- **Speed.** The persona/rule install runs `create_persona` and `create_rule` 15 times and requires parsing the ~62KB `PERSONAS-AND-RULES.md` doc with nested code fences inside persona prompts. That step alone takes 3-5 minutes on the agent. Removing it from the install path drops the autonomous portion from ~7 minutes to ~30 seconds — meaningful for fresh-user UX, particularly tutorial videos.
+- **Decoupling.** Skills work as standalone CLIs. The persona layer is *chat-UX discipline* (regime-first framing, persona handoff, kill-condition enforcement) — useful, but not required for the underlying scripts to produce correct output. Users who only want to invoke skills programmatically (or who have their own chat-UX preferences) shouldn't pay the install cost.
+
+Re-running `clarion-setup` is safe and never modifies personas or rules — those live in Zo Settings → AI and are owned by the user.
+
 ## The big architectural pivot: skills, not MCP servers
 
 Clarion Trading Platform exposes MCP servers (`spy-tlt-strat`, `single-stock-strat`, `sec-rag`) over stdio. **That pattern does not work on Zo.** Zo is itself an MCP server (`https://api.zo.computer/mcp`) — it exposes its own tools to external MCP clients, but it does not host external MCP servers.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Built around principles from Berkshire Hathaway and Buffett's annual letters, ad
 
 ## Install
 
-A brand-new Zo user is fully set up in ~3-5 minutes.
+The autonomous portion of the install runs in ~30 seconds; you spend ~2 minutes creating one Zo secret. Total ~3 minutes start-to-finish.
 
 ### Quick start
 
@@ -20,7 +20,9 @@ Paste this into Zo chat:
 
 > Install the clarion-setup skill and set up Clarion.
 
-That's the entire install. Zo handles everything — installs the bootstrap skill, clones the repo, installs the library, creates the workspace, registers the background service, installs all sibling skills, installs personas and routing rules — autonomously. It pauses **once** near the end for two inputs from you (your SEC EDGAR name+email AND creating the `ZO_API_KEY` Zo secret); everything else runs hands-off.
+Zo installs the bootstrap skill, clones the repo, installs the library, creates the workspace, installs all sibling skills, and registers the background service — autonomously, ~30 seconds. It pauses **once** for two inputs from you (your SEC EDGAR name+email AND creating the `ZO_API_KEY` Zo secret), then verifies the service is running and reports.
+
+Persona routing (the 7 Clarion personas + 8 chat rules that enforce regime-first framing and persona handoff) is **opt-in via a separate prompt** after the install completes — see [Add persona routing (optional)](#add-persona-routing-optional) below. The bare install gives you everything to evaluate stocks and pull SEC filings; persona routing is a chat-UX layer on top.
 
 ### What you'll be asked at the human checkpoint
 
@@ -61,24 +63,35 @@ For reference — the Quick-start prompt above triggers all of this autonomously
 4. Creates the `~/clarion/` workspace tree (`data/`, `sec/`, `queue/`, `theses/`, `watchlists/`, `letters/`) plus default `config.json`
 5. Auto-installs all nine sibling `clarion-*` skills under `/home/workspace/Skills/`
 6. Registers the `sec-indexer` background service (in FATAL state until the human checkpoint finishes — that's expected)
-7. Installs the 7 Clarion personas into Zo Settings → AI → Personas
-8. Installs 8 Clarion routing rules (Rule 3 + Rules 5–11) into Zo Settings → AI → Rules
-9. **Pauses for the human checkpoint** (see above)
-10. After your input: writes SEC identification to `config.json`, restarts `sec-indexer`, verifies via `service_doctor`, reports completion
+7. **Pauses for the human checkpoint** (see above)
+8. After your input: writes SEC identification to `config.json`, restarts `sec-indexer`, verifies via `service_doctor`, reports completion
 
 Setup is idempotent — safe to re-run. On a clean re-run (nothing customized, secret already exists, SEC identification already set), the human checkpoint is skipped entirely.
+
+The autonomous SEC indexer service is **queue-driven** — it idles after install with zero API calls until you (or a Clarion skill) explicitly enqueues a filing via `clarion-sec-research index TICKER`. Nothing is pre-indexed.
 
 ### Use it conversationally
 
 That's it. Now ask Zo things like:
 
 - "What's the market regime right now?"
-- "Analyze NVDA's most recent 10-K risk factors."
+- "Evaluate AAPL." *(indexes the latest 10-K + runs the Buffett-lens eval — ~2 minutes on first invocation)*
 - "Has there been any insider activity at NVDA?" *(Form 4)*
-- "Evaluate KO as a long-term holding."
 - "Run a value screen at my hurdle rate."
 - "Write a thesis on TTD."
 - "What's hit my watchlist this week?"
+
+### Add persona routing (optional)
+
+The skills above are functional standalone. Personas + routing rules add the **chat-layer discipline** — regime-first framing, automatic persona handoff (Macro Sentinel → Analyst → Thesis Architect → Portfolio Manager), kill-condition enforcement, and the return-to-default rule for non-investment queries.
+
+To add persona routing, paste this prompt into Zo chat:
+
+> Install Clarion personas and routing rules.
+
+This takes ~3 minutes (it parses `docs/PERSONAS-AND-RULES.md` and creates 7 personas + 8 rules via `create_persona` / `create_rule`). After it's done, Clarion responses route through specialist personas automatically based on what you ask. See [`docs/PERSONAS-AND-RULES.md`](./docs/PERSONAS-AND-RULES.md) for the full persona/rule definitions.
+
+To skip entirely: do nothing. The Buffett-style evaluation skills, regime check, value screener, thesis tools, and SEC indexing all work without personas — they just answer in Zo's default tone instead of routing through specialist voices.
 
 ## Updating
 
@@ -86,9 +99,11 @@ When upstream ships fixes, re-run `clarion-setup` to pull them down:
 
 > set up Clarion
 
-This `git pull`s the source, re-installs the library, refreshes the sibling skills under `/home/workspace/Skills/`, and — if there are doc updates — asks you before replacing any customized personas or rules. On a clean re-run (you didn't customize anything, secret already exists, sec_user_agent already set), the human checkpoint in step 3 is skipped automatically and the whole flow is autonomous.
+This `git pull`s the source, re-installs the library, and refreshes the sibling skills under `/home/workspace/Skills/`. On a clean re-run (secret already exists, sec_user_agent already set), the human checkpoint is skipped automatically and the whole flow is autonomous.
 
 The skill restarts `sec-indexer` automatically as part of the re-run, so updated library code is loaded into the running process. No separate "restart the service" command needed.
+
+Personas and routing rules are **not** modified by `clarion-setup` re-runs — they're owned by the user (set via the optional persona install prompt). If you want updated persona/rule text after pulling new upstream docs, run *"install Clarion personas and routing rules"* again; it'll ask before replacing any existing entries.
 
 ## Skills
 

--- a/docs/PERSONAS-AND-RULES.md
+++ b/docs/PERSONAS-AND-RULES.md
@@ -12,6 +12,16 @@ Without these personas, a new user gets a generic Zo chat experience: tools that
 
 ## How to install
 
+**Fast path — one prompt.** After completing the main `clarion-setup` install, paste this into Zo chat:
+
+> Install Clarion personas and routing rules.
+
+This takes ~3 minutes. Zo reads this doc, extracts the 7 personas + 8 rules (Rule 3 + Rules 5–11; skips Rules 1, 2, 4, 12 which depend on operator-personal infrastructure), and creates them via `create_persona` / `create_rule`. Idempotent: if Clarion personas or rules already exist, Zo asks before replacing each one.
+
+If you prefer manual control (or are inspecting the prompts before pasting), use the manual path below.
+
+### Manual path
+
 Each persona and rule below can be created in Zo Settings:
 
 *Note: the links below resolve inside the Zo client. On GitHub, they appear as relative URLs.*
@@ -21,6 +31,8 @@ Each persona and rule below can be created in Zo Settings:
 3. Switch between personas from the chat interface depending on the task
 
 Personas can be assigned to specific channels (chat, SMS, email) or switched manually mid-conversation.
+
+**Why this is opt-in.** Personas + routing rules add chat-layer discipline (regime-first framing, automatic handoff between specialist personas, kill-condition enforcement). The Clarion skills work without them — they just answer in Zo's default tone. Removing personas from the `clarion-setup` autonomous install path drops setup time from ~7 minutes to ~30 seconds; users who want the full chat-routing experience opt in via the prompt above.
 
 ---
 

--- a/docs/TEST-PLAN.md
+++ b/docs/TEST-PLAN.md
@@ -2,7 +2,7 @@
 
 A progressive stress test for a fresh Zo Computer install. Three tiers:
 
-- **Tier 1** (~10 min) — smoke test: install, service, simplest end-to-end query.
+- **Tier 1** (~5 min) — smoke test: install, service, simplest end-to-end query.
 - **Tier 2** (~30 min) — functional coverage: every skill exercised once + cross-skill composition.
 - **Tier 3** (~as needed) — stress and regression: edge cases, error paths, previously-fixed bugs.
 
@@ -18,7 +18,9 @@ For each test, record: Pass / Fail / Skipped + a one-line output excerpt or erro
 
 **Prompt:** `Install the clarion-setup skill and set up Clarion.`
 
-**Pass:** Zo installs the bootstrap skill from the registry, then invokes it. The skill runs autonomously through: clone source repo → install lib → create workspace tree → write placeholder `config.json` → auto-install nine sibling `clarion-*` skills → register `sec-indexer` service (will be in FATAL state, expected) → install 7 Clarion personas → install 8 Clarion routing rules (Rule 3 + Rules 5–11). Then pauses for the batched human checkpoint described in T1.2.
+**Pass:** Zo installs the bootstrap skill from the registry, then invokes it. The skill runs autonomously through: clone source repo → install lib → create workspace tree → write placeholder `config.json` → auto-install nine sibling `clarion-*` skills → register `sec-indexer` service (will be in FATAL state, expected). Total autonomous runtime: ~30 seconds. Then pauses for the batched human checkpoint described in T1.2.
+
+**Personas and routing rules are NOT installed in T1.1.** They're the chat-UX layer and have moved to an opt-in T1.5 prompt below.
 
 ### T1.2 — Batched human checkpoint
 
@@ -46,22 +48,28 @@ Jane Doe jane@example.com
 
 **Pass:** Subdirs `data/equities`, `sec`, `queue`, `theses`, `watchlists`, `letters`, plus `config.json`. Check `cat ~/clarion/config.json | grep sec_user_agent` — should be your real name+email, NOT the placeholder `clarion@example.com`.
 
-### T1.4 — Verify personas and rules were installed
-
-**Prompts:**
-
-1. *(via agent tool)* `list_personas()` — should return at least the 7 Clarion personas (Data-First Plain Talk, Clarion Macro Sentinel, Clarion Value Screener, Clarion Analyst, Clarion Thesis Architect, Clarion Portfolio Manager, Clarion LP Voice).
-2. *(via agent tool)* `list_rules()` — should return at least 8 Clarion rules (Rule 3 — live market data, Rules 5–11 — routing + return-to-default).
-
-**Pass:** All 7 Clarion personas and 8 Clarion rules present. Names match the doc.
-
-### T1.5 — Regime check (auto-routes to Macro Sentinel persona)
+### T1.4 — Regime check (skills work without personas)
 
 **Prompt:** `what's the market regime?`
 
-**Pass:** Rule 6 routes to the Clarion Macro Sentinel persona (verify by checking which persona answered, or by output style — terse, regime-first, hurdle-rate framing). Returns SPY/TLT/RSP color and the equity hurdle rate. Fast (no indexing). Proves the chat-skill auto-token path works without `ZO_API_KEY` in scope (chat skills get `ZO_CLIENT_IDENTITY_TOKEN` auto-injected; only the `sec-indexer` service needs `ZO_API_KEY`).
+**Pass:** Returns SPY/TLT/RSP color and the equity hurdle rate. Fast (no indexing). Output is in Zo's default tone (no persona routing yet — that's T1.5). Proves the chat-skill auto-token path works without `ZO_API_KEY` in scope (chat skills get `ZO_CLIENT_IDENTITY_TOKEN` auto-injected; only the `sec-indexer` service needs `ZO_API_KEY`).
 
-### T1.6 — SEC research happy path (auto-routes to Analyst when appropriate)
+### T1.5 — Install Clarion personas and routing rules (optional)
+
+**Prompt:** `install Clarion personas and routing rules`
+
+**Pass:** Zo parses `docs/PERSONAS-AND-RULES.md` and creates 7 Clarion personas (Data-First Plain Talk, Clarion Macro Sentinel, Clarion Value Screener, Clarion Analyst, Clarion Thesis Architect, Clarion Portfolio Manager, Clarion LP Voice) + 8 routing rules (Rule 3 + Rules 5–11). Total runtime: ~3 minutes.
+
+**Verify:**
+
+1. *(via agent tool)* `list_personas()` — returns at least the 7 Clarion personas. Names match the doc.
+2. *(via agent tool)* `list_rules()` — returns at least 8 Clarion rules. Conditions match the doc.
+
+**Re-run with the same prompt is idempotent**: should detect existing entries and ask before replacing.
+
+**Skip T1.5 if you're testing the "skills only" install path**, then proceed to T1.6 without persona routing.
+
+### T1.6 — SEC research happy path
 
 **Prompts:**
 
@@ -71,7 +79,9 @@ Jane Doe jane@example.com
 
 **Pass:** Indexing completes. Search returns a hit table + top-5 snippets. Every snippet has a canonical citation: `NVDA 10-K filed YYYY-MM-DD → section`. *(`clarion-sec-research` is auto-installed by setup — no separate install step needed.)*
 
-**Tier 1 passes if T1.1-T1.6 all worked with the single install prompt and one batched human checkpoint.**
+If T1.5 was run, the response routes through the Clarion Analyst persona (Rule 5 fires on the third prompt) and reads with the Analyst's voice. If T1.5 was skipped, the response comes in Zo's default tone with the same factual content.
+
+**Tier 1 passes if T1.1-T1.4 and T1.6 all worked with the single install prompt and one batched human checkpoint. T1.5 is optional and tests the persona routing layer independently.**
 
 ## Tier 2 — Full functional coverage
 
@@ -176,13 +186,13 @@ Jane Doe jane@example.com
 
 **Pass:**
 
-- All Step 1–5 actions are idempotent (clone is `git pull --ff-only`; lib re-install is no-op; data tree `mkdir -p`; existing personas/rules not silently replaced).
-- Step 4 (persona install) and Step 5 (rule install) call `list_personas()` / `list_rules()` first, find the existing Clarion entries, and **ask the user** before replacing. Answer "no" — verify nothing is replaced.
-- Step 6 (human checkpoint) is **fully skipped** on a clean re-run — both pre-checks pass (`sec_user_agent` is non-placeholder, `service_doctor` shows RUNNING).
-- Step 7b automatically restarts `sec-indexer` so any updated lib code (from the `git pull`) is loaded into the running process. No separate "restart the service" command needed.
-- Step 8 verifies `service_doctor(service="sec-indexer")` shows RUNNING with non-zero uptime post-restart.
+- All Step 1–3 actions are idempotent (clone is `git pull --ff-only`; lib re-install is no-op; data tree `mkdir -p`; sibling skills refreshed in place).
+- Step 4 (human checkpoint) is **fully skipped** on a clean re-run — both pre-checks pass (`sec_user_agent` is non-placeholder, `service_doctor` shows RUNNING).
+- Step 5b automatically restarts `sec-indexer` so any updated lib code (from the `git pull`) is loaded into the running process. No separate "restart the service" command needed.
+- Step 6 verifies `service_doctor(service="sec-indexer")` shows RUNNING with non-zero uptime post-restart.
+- **Personas and rules are NOT touched** by re-runs — they're owned by the user (set via the optional "install Clarion personas and routing rules" prompt). Pre-existing personas and rules survive the re-run untouched. Verify by running `list_personas()` and `list_rules()` before and after — the counts and IDs match.
 
-**This is the verification for the auto-restart and skip-checkpoint patches:** editable `uv pip install -e` doesn't reload an already-running service, so the restart must fire automatically in Step 7b; and re-running with everything already configured should not re-prompt the user for inputs already on file.
+**This is the verification for the auto-restart and skip-checkpoint patches:** editable `uv pip install -e` doesn't reload an already-running service, so the restart must fire automatically in Step 5b; and re-running with everything already configured should not re-prompt the user for inputs already on file. The persona/rule preservation is the verification that `clarion-setup` correctly scopes itself to functional layer only.
 
 ### T3.4 — Service restart
 
@@ -275,4 +285,4 @@ Update this test plan when:
 - A bug is found in production → add a Tier 3 regression case so it can't return silently
 - A skill's description changes → update the routing tests in Tier 3
 
-Source: `github.com/jingerzz/clarion-intelligence-system`. Last reviewed against commit `7430985` (2026-05-19), updated to reflect the single-prompt install flow (PR #21), the SEC user-agent fix, the persona/rule auto-install path (PR #21 + Zo platform agent tools), and the post-PR #20 service-startup verification via `service_doctor`. T2.10 added for the operator-personal `clarion-portfolio-monitor` skill (PR #15).
+Source: `github.com/jingerzz/clarion-intelligence-system`. Last reviewed 2026-05-20: T1 reorganized to reflect the leaner install — personas/rules moved out of the autonomous path and into the optional T1.5 prompt ("install Clarion personas and routing rules"). T3.3 updated to verify that re-runs preserve user-owned personas/rules untouched. T2.10 added for the operator-personal `clarion-portfolio-monitor` skill (PR #15).

--- a/skills/clarion-setup/SKILL.md
+++ b/skills/clarion-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clarion-setup
-description: Bootstraps the Clarion Intelligence System on Zo Computer. Run this once after installing — clones the source repo, installs the ai_buffett_zo Python library, creates the workspace data tree under /home/workspace/clarion/ (auto-detected on Zo), auto-installs all nine sibling clarion-* skills (regime-check, sec-research, single-stock-eval, expected-return-calc, value-screener, thesis-write, thesis-monitor, watchlist-update, living-letter-update) under /home/workspace/Skills/, registers the sec-indexer background service, and installs the 7 Clarion personas + 8 routing rules into Zo Settings. Idempotent (safe to re-run; asks before replacing customized personas/rules). The only manual step is one batched human checkpoint near the end (SEC EDGAR name + email, and creating the ZO_API_KEY secret). Use when the user asks to "set up Clarion" or "install Clarion".
+description: Bootstraps the Clarion Intelligence System on Zo Computer. Run this once after installing — clones the source repo, installs the ai_buffett_zo Python library, creates the workspace data tree under /home/workspace/clarion/ (auto-detected on Zo), auto-installs all nine sibling clarion-* skills (regime-check, sec-research, single-stock-eval, expected-return-calc, value-screener, thesis-write, thesis-monitor, watchlist-update, living-letter-update) under /home/workspace/Skills/, and registers the sec-indexer background service. Idempotent (safe to re-run). The only manual step is one batched human checkpoint near the end (SEC EDGAR name + email, and creating the ZO_API_KEY secret). Persona routing for Clarion is opt-in via a separate prompt after install ("install Clarion personas and routing rules"). Use when the user asks to "set up Clarion" or "install Clarion".
 metadata:
   author: cis.zo.computer
   category: External
@@ -14,7 +14,9 @@ Bootstraps the Clarion Intelligence System on a Zo workspace. Run this once befo
 
 ## Flow at a glance
 
-This skill is designed for a **single-prompt install** experience. Steps 1–5 run autonomously (clone, library, data tree, register service, install personas + rules). Step 6 is one batched human checkpoint — the user supplies their SEC EDGAR identification and creates the `ZO_API_KEY` secret in Zo Settings. Steps 7–9 resume autonomously to apply the user's input, restart the service, verify it's running, and report.
+This skill is designed for a **single-prompt install** experience that delivers the working system (library, skills, service) fast — typically ~30 seconds of autonomous work plus the user's time creating the `ZO_API_KEY` secret. Steps 1–3 run autonomously (clone, library, data tree, register service). Step 4 is one batched human checkpoint — the user supplies their SEC EDGAR identification and creates the `ZO_API_KEY` secret in Zo Settings. Steps 5–7 resume autonomously to apply the user's input, restart the service, verify it's running, and report.
+
+**Personas and routing rules are NOT installed by this skill.** They're the chat-layer discipline (regime-first framing, kill-condition enforcement, persona handoff between Macro Sentinel → Analyst → Thesis Architect → Portfolio Manager). The bare install delivers everything needed to evaluate a stock from chat; persona routing is opt-in via a follow-up prompt described in Step 7 — typically a separate ~3-minute step the user takes after they've tried a few queries.
 
 Walk through the steps below in order. Stop and surface any failure to the user immediately — do not proceed past a failure.
 
@@ -48,7 +50,7 @@ The script is idempotent. It will:
 - Verify the `sec-indexer` console script is on PATH
 - Install every sibling `clarion-*` skill from the repo into `/home/workspace/Skills/` (refreshes any already-installed copies; pass `--skip-skills` to opt out)
 - Print service registration parameters between `--- BEGIN SERVICE_REGISTRATION ---` and `--- END SERVICE_REGISTRATION ---`
-- Print a `USER_ACTION_REQUIRED` block (you'll surface this in Step 6)
+- Print a `USER_ACTION_REQUIRED` block (you'll surface this in Step 4)
 - Print a final `SETUP_RESULT: ok` line on success, or `SETUP_RESULT: error: <reason>` on failure
 
 If you do NOT see `SETUP_RESULT: ok`, surface the error to the user verbatim and stop.
@@ -70,67 +72,20 @@ Use the `register_user_service` agent tool with the parameters printed in the `S
 {"ZO_API_KEY": "$ZO_API_KEY", "CLARION_DATA_ROOT": "/home/workspace/clarion"}
 ```
 
-Do **not** wrap it in quotes and escape it like `"{\"ZO_API_KEY\": \"$ZO_API_KEY\", ...}"`. If the tool call appears to require escape sequences inside `env_vars`, stop and re-form the call — the parameter is an object, not a string. Models that try to escape this end up generating malformed input that either fails outright or — worse — succeeds with corrupted values (env vars inlined into the entrypoint shell-string, trailing XML-tag artifacts appended to the entrypoint, `CLARION_DATA_ROOT` silently dropped). The verification at Step 8 catches the corrupted-success case; the prevention is to get the env_vars shape right here.
+Do **not** wrap it in quotes and escape it like `"{\"ZO_API_KEY\": \"$ZO_API_KEY\", ...}"`. If the tool call appears to require escape sequences inside `env_vars`, stop and re-form the call — the parameter is an object, not a string. Models that try to escape this end up generating malformed input that either fails outright or — worse — succeeds with corrupted values (env vars inlined into the entrypoint shell-string, trailing XML-tag artifacts appended to the entrypoint, `CLARION_DATA_ROOT` silently dropped). The verification at Step 6 catches the corrupted-success case; the prevention is to get the env_vars shape right here.
 
-**Expected state after Step 3: the service is in `FATAL` or `BACKOFF`.** This is normal and expected. `$ZO_API_KEY` resolves from a Zo secret that doesn't exist yet (the user creates it in Step 6). The supervisor will try to launch `sec-indexer`, the binary will fail to authenticate against Zo's API, and the service will retry-backoff. **Do NOT call `service_doctor` yet. Do NOT delete and re-register. Continue to Step 4.** The restart in Step 7, after the secret exists, brings the service to RUNNING.
+**Expected state after Step 3: the service is in `FATAL` or `BACKOFF`.** This is normal and expected. `$ZO_API_KEY` resolves from a Zo secret that doesn't exist yet (the user creates it in Step 4). The supervisor will try to launch `sec-indexer`, the binary will fail to authenticate against Zo's API, and the service will retry-backoff. **Do NOT call `service_doctor` yet. Do NOT delete and re-register. Continue to Step 4.** The restart in Step 5, after the secret exists, brings the service to RUNNING.
 
 If `register_user_service` itself returns an error (not just a FATAL state — an actual tool error), check the env_vars formatting above first, then surface the error.
 
-## Step 4 — Install the 7 Clarion personas
-
-Read `/home/workspace/clarion-intelligence-system/docs/PERSONAS-AND-RULES.md`.
-
-For each of the 7 personas — sections `## Persona 1 — Data-First Plain Talk` through `## Persona 7 — Clarion LP Voice`:
-
-1. **Extract the persona name** from the section heading. Examples:
-   - `## Persona 1 — Data-First Plain Talk` → name is `Data-First Plain Talk`
-   - `## Persona 2 — Clarion Macro Sentinel` → name is `Clarion Macro Sentinel`
-2. **Extract the persona's prompt text** — it's the contents of the *outermost* triple-backtick code block within the persona's section (before the next `## Persona` heading or the next top-level section). Note: persona prompts contain *nested* triple-backtick blocks for bash examples; you want the outermost one only.
-3. **Check whether a persona with this name already exists**:
-   - Call `list_personas()` and filter client-side by `name`.
-   - If a match exists, ask the user: *"I see an existing Clarion persona named '\<NAME\>'. Replace it with the latest version from the doc? (yes/no)"* Wait for the answer.
-     - If **yes**: call `delete_persona(persona_id=<existing_id>)`, then proceed to create.
-     - If **no**: skip this persona entirely; do not create a duplicate. Note the existing `id` in the persona-ID map for Step 5.
-   - If no match exists, proceed to create.
-4. **Create the persona**: call `create_persona(name="<extracted name>", prompt="<extracted prompt>")`. The tool response contains the new persona's `id`. If the response shape is unexpected and you can't find the `id`, fall back to calling `list_personas()` again and filtering by name to recover the new id.
-5. **Record** the mapping `{persona_name → persona_id}` for use in Step 5.
-
-After all 7 personas, you should have a complete mapping covering all 7 Clarion persona names. Surface any persona that was skipped (user said "no" to replacement) — the corresponding rule in Step 5 still needs an ID to reference, so the existing persona's ID must be in the map.
-
-## Step 5 — Install Clarion rules
-
-Read the same `PERSONAS-AND-RULES.md` file. **Install Rules 3, 5, 6, 7, 8, 9, 10, and 11. SKIP Rules 1, 2, and 4** — they reference operator-personal infrastructure not installed by Clarion (memory layer, Zo Space verification). The doc has explicit scope notes confirming this.
-
-For each rule to install:
-
-1. **Extract the rule's Condition text** — the prose body after `**Condition:**` (a single paragraph, not in a code block).
-2. **Extract the rule's Instruction text** — the contents of the triple-backtick block under `**Instruction:**`.
-3. **For Rules 5–11 (the routing rules)**, the Instruction text contains a persona ID. The doc's checked-in value is the author's instance-specific UUID OR the placeholder `<your Persona N UUID>` (for Rule 11). **Replace it with the actual persona ID** you captured in Step 4, matched by name:
-   - Rule 5 (stock evaluation) → `Clarion Analyst`
-   - Rule 6 (regime questions) → `Clarion Macro Sentinel`
-   - Rule 7 (thesis monitoring / portfolio status) → `Clarion Portfolio Manager`
-   - Rule 8 (thesis writing) → `Clarion Thesis Architect`
-   - Rule 9 (value screens) → `Clarion Value Screener`
-   - Rule 10 (investor letter) → `Clarion LP Voice`
-   - Rule 11 (return to default) → `Data-First Plain Talk`
-4. **Check whether a Clarion routing rule with this condition already exists**:
-   - Call `list_rules()` and compare each existing rule's condition text to the one you're about to install. Compare the first ~80 characters (handles minor wording variations across doc versions).
-   - If a match exists, ask the user: *"I see an existing Clarion rule for '\<condition snippet\>'. Replace it? (yes/no)"* Wait for the answer.
-     - If **yes**: call `delete_rule(rule_id=<existing_id>)`, then proceed to create.
-     - If **no**: skip this rule.
-   - If no match exists, proceed to create.
-5. **Create the rule**: call `create_rule(instruction="<substituted instruction>", condition="<condition>")`.
-
-Total expected after Step 5: **8 Clarion rules installed** (Rule 3 + Rules 5–11).
-
-## Step 6 — Batched human checkpoint (the only manual step)
+## Step 4 — Batched human checkpoint (the only manual step)
 
 **Pre-check (skip the whole checkpoint on a clean re-run).** Before asking the user for anything, check both of:
 
 1. `/home/workspace/clarion/config.json`'s `sec_user_agent` field — is it the placeholder `Clarion Intelligence System (clarion@example.com)`, or a real user value?
 2. `service_doctor(service="sec-indexer")` — is the service already RUNNING with non-zero uptime? (If yes, the `ZO_API_KEY` secret already exists, since the service couldn't have started without it.)
 
-If `sec_user_agent` is a real value AND the service is already RUNNING, **skip Step 6 entirely** — there's nothing for the user to do. Tell the user *"detected a complete prior install — skipping the human checkpoint and going straight to a refresh restart."* Jump to Step 7b (restart only, no config.json write needed).
+If `sec_user_agent` is a real value AND the service is already RUNNING, **skip Step 4 entirely** — there's nothing for the user to do. Tell the user *"detected a complete prior install — skipping the human checkpoint and going straight to a refresh restart."* Jump to Step 5b (restart only, no config.json write needed).
 
 Otherwise, you need at least one of two inputs from the user. **Surface both together so they can multitask** — the user can type their SEC identification in chat while simultaneously navigating Zo Settings to create the secret.
 
@@ -154,9 +109,9 @@ Wait for the user to reply with:
 
 If the user only replies to one of the two, prompt for the other before continuing.
 
-## Step 7 — Apply user inputs and restart the service
+## Step 5 — Apply user inputs and restart the service
 
-### 7a — Write the SEC user-agent to config.json (only if Input A produced a value)
+### 5a — Write the SEC user-agent to config.json (only if Input A produced a value)
 
 Substitute the user's reply into this command and run it:
 
@@ -166,7 +121,7 @@ python3 -c "import json, pathlib; p = pathlib.Path('/home/workspace/clarion/conf
 
 Replace `<USER_INPUT_VERBATIM>` with the user's exact reply (no quotes around it inside the Python string — the outer quotes are already there). Confirm the write by reading the file back and showing the `sec_user_agent` line.
 
-### 7b — Restart the sec-indexer service
+### 5b — Restart the sec-indexer service
 
 Call `update_user_service` with the existing `sec-indexer` service_id and `action="restart"`. This:
 - Causes the supervisor to re-evaluate `$ZO_API_KEY` (now that the secret exists)
@@ -174,7 +129,7 @@ Call `update_user_service` with the existing `sec-indexer` service_id and `actio
 
 Confirm the restart command succeeded.
 
-## Step 8 — Verify the service is actually running (do not skip)
+## Step 6 — Verify the service is actually running (do not skip)
 
 Call the `service_doctor` agent tool:
 
@@ -202,11 +157,12 @@ As a separate (weaker) sanity check that the binary is reachable on PATH:
 
 ```bash
 sec-indexer --help
+
 ```
 
-This proves the executable resolves on PATH, but does NOT prove the service is running. Step 8's `service_doctor` is the actual validation.
+This proves the executable resolves on PATH, but does NOT prove the service is running. Step 6's `service_doctor` is the actual validation.
 
-## Step 9 — Report and explain
+## Step 7 — Report and explain
 
 Tell the user:
 
@@ -216,13 +172,13 @@ Tell the user:
 > - Workspace data: the path printed in the `[2/6] Creating data tree under …` line from setup.py (typically `/home/workspace/clarion/` on Zo, `~/clarion/` on a local machine — auto-detected)
 > - Background service: `sec-indexer` (running)
 > - Skills installed under `/home/workspace/Skills/`: every sibling `clarion-*` skill from setup.py's `[5/6]` block. List the actual names returned.
-> - Personas installed in Zo Settings → AI: the 7 Clarion personas you created in Step 4. List them by name (Data-First Plain Talk, Clarion Macro Sentinel, Clarion Value Screener, Clarion Analyst, Clarion Thesis Architect, Clarion Portfolio Manager, Clarion LP Voice).
-> - Rules installed in Zo Settings → AI: 8 Clarion rules (Rule 3 — live market data; Rules 5–10 — persona routing; Rule 11 — return to default).
 > - SEC EDGAR identification: `<the user's name and email from config.json>` (the actual value, not the placeholder).
 >
-> Just ask me things like *"what's the market regime?"*, *"evaluate NVDA"*, *"update my watchlist"*, *"write a thesis on TTD"*, *"show me my portfolio"*, or *"update the Q1 letter"*.
+> Try it out — ask me things like *"evaluate AAPL"*, *"what's the market regime?"*, *"index NVDA's latest 10-K"*, or *"run a value screen on AAPL, KO, JNJ"*. The skills work as standalone CLIs too.
+>
+> **Optional next step — install Clarion's persona routing for the full chat experience.** This adds the 7 Clarion personas (Macro Sentinel, Analyst, Thesis Architect, Portfolio Manager, etc.) and 8 routing rules that enforce regime-first framing, kill-condition discipline, and automatic persona handoff. Takes ~3 minutes. To opt in, just say: *"install Clarion personas and routing rules"*. To skip: do nothing — the skills above all work without it.
 
-If anything in this report differs from the expected state (e.g., fewer than 7 personas, fewer than 8 rules, service not RUNNING, sec_user_agent is still the placeholder), call this out explicitly. Do not paper over partial-install state.
+If anything in this report differs from the expected state (e.g., service not RUNNING, sec_user_agent is still the placeholder), call this out explicitly. Do not paper over partial-install state.
 
 ## Idempotency
 
@@ -234,15 +190,15 @@ Re-running this skill is safe. Each step:
 - **Config.json**: preserved if present — including any `sec_user_agent` the user previously set. The setup script does NOT overwrite an existing config.
 - **Skill install**: each sibling `clarion-*` skill in `/home/workspace/Skills/` is refreshed (overwritten) with the upstream copy. This is the intended path to pull in upstream skill fixes after a `git pull`.
 - **Service registration**: if the user already has a `sec-indexer` service, `register_user_service` should report it exists; treat that as success and continue.
-- **Persona install**: Step 4 calls `list_personas()` and asks the user before replacing any existing Clarion persona. User customizations are preserved unless the user opts in to replacement. The order is "ask first, then replace" — never silent overwrite.
-- **Rule install**: Same — Step 5 calls `list_rules()` and asks before replacing.
-- **Human checkpoint**: Step 6's Input A is skipped if `config.json` already has a non-placeholder `sec_user_agent`. Step 6's Input B is essentially "if the secret already exists, the user replies `done` immediately and the SKILL.md's USER_ACTION_REQUIRED message instructs them this is OK."
+- **Human checkpoint**: Step 4's Input A is skipped if `config.json` already has a non-placeholder `sec_user_agent`. Step 4's Input B is essentially "if the secret already exists, the user replies `done` immediately and the SKILL.md's USER_ACTION_REQUIRED message instructs them this is OK."
+
+Personas and routing rules are not touched by re-runs because they're not installed by this skill. They live in Zo Settings → AI → Personas / Rules and are managed by the user (or by the separate persona-install prompt). A re-run of clarion-setup never adds, removes, or modifies personas or rules.
 
 ### Re-running to pick up source updates
 
 Editable installs (`uv pip install -e`) do NOT reload an already-running service — the `sec-indexer` process keeps the Python modules it imported at startup in memory. After a `git pull` brings in new code, you MUST restart the service for the changes to take effect.
 
-If the user is re-running setup specifically to pull in upstream fixes, the existing Step 7b restart in this flow handles this naturally. After Step 8 verifies RUNNING, the new code is live.
+If the user is re-running setup specifically to pull in upstream fixes, the existing Step 5b restart in this flow handles this naturally. After Step 6 verifies RUNNING, the new code is live.
 
 ## On error
 
@@ -252,6 +208,4 @@ If any step fails, do not silently proceed. Read the error, summarize the cause,
 - **`uv: command not found`** — same.
 - **`uv pip install` fails with venv error** — the script tries `--system` automatically; if it still fails, ask the user to share the full error.
 - **`register_user_service` fails with a JSON-escaping or "runner stopped" error** — re-read the *env_vars formatting* guidance in Step 3. The most common cause is `env_vars` being passed as a stringified JSON instead of an object. Re-form the call and retry.
-- **`create_persona` / `create_rule` returns an error** — surface the error verbatim. Possible causes include a tool-not-available environment, malformed prompt text (check the extracted code block for stray markdown), or a transient platform error (retry once before giving up).
-- **`service_doctor` shows non-RUNNING after Step 7's restart** — follow the Step 8 troubleshooting (inspect entrypoint via `list_user_services()`, inspect logs, delete + re-register if entrypoint is corrupted). Do NOT mark setup complete.
-- **The user replies "no" to replacing personas/rules in Step 4/5** — that's their right. Continue with the existing persona's ID in the map for Step 5's rule substitutions. The final report in Step 9 should mention which personas/rules were preserved vs. created.
+- **`service_doctor` shows non-RUNNING after Step 5's restart** — follow the Step 6 troubleshooting (inspect entrypoint via `list_user_services()`, inspect logs, delete + re-register if entrypoint is corrupted). Do NOT mark setup complete.


### PR DESCRIPTION
## Summary

- Scopes back the `clarion-setup` autonomous install to **library + sibling skills + sec-indexer service registration** — dropping the autonomous portion from ~7 minutes to ~30 seconds.
- Personas and routing rules become **opt-in via a follow-up prompt** (*"install Clarion personas and routing rules"*) — see updated `docs/PERSONAS-AND-RULES.md`.
- No changes to `setup.py` (it already does the right thing — no SEC indexing, no persona/rule work).

## Why

Real user install transcript (Anthea Taeuber, 2026-05-20) timing breakdown across the ~7m 34s autonomous run before the human checkpoint:

| Phase | Time |
|---|---|
| Initial discovery (list_files, read SKILL.md, read README) | ~1m 10s |
| Pre-work (list_personas, list_rules, list_user_services, tool_docs) | ~1m 00s |
| **setup.py + sibling skills install** | **~10s** |
| **register_user_service** | **~8s** |
| **PERSONAS-AND-RULES.md parsing (5 attempts, multiple Python scripts, multiple chunked reads)** | **~3m 30s** |
| **create_persona × 7** | **~1m 04s** |
| **create_rule × 8** (parallel) | **~14s** |

The persona/rule work is the bottleneck — agents struggle to parse the 62KB doc with nested triple-backtick code fences inside persona prompts. **SEC indexing was NOT a factor** (zero EDGAR fetches during install — the indexer is purely queue-driven and the queue is empty post-install). Verified by reading the full pipeline:

- `setup.py` grep for `enqueue` / `IndexRequest` → zero matches
- `lib/ai_buffett_zo/indexer/main.py:213-225` → `for req in list_pending(queue_root): process_one(...)` over an empty queue is a no-op
- Only `skills/clarion-sec-research/scripts/research.py:82-112` enqueues — and only when the user runs it

Skills are functional standalone — verified by reading `lib/`, `skills/`, and the indexer pipeline. The persona layer is chat-UX discipline, not a functional gate. Decoupling preserves the demo arc *(install → ask "evaluate AAPL" → see the eval)* at ~30 seconds of autonomous time, suitable for tutorial videos and fresh-user impressions.

## Changes

| File | Change |
|---|---|
| `skills/clarion-setup/SKILL.md` | Removes Steps 4 (personas) + 5 (rules). Renumbers remaining steps (4 = human checkpoint, 5 = restart, 6 = verify, 7 = report). Updates frontmatter description. Updates "Flow at a glance" intro. Step 7 now suggests *"install Clarion personas and routing rules"* as an optional follow-up. Idempotency + on-error sections updated. |
| `README.md` | Updates Quick-start expectation (autonomous portion ~30s instead of ~5min). Adds **Add persona routing (optional)** section documenting the follow-up prompt + manual-install fallback. Updates "What the install does behind the scenes" to match. |
| `docs/PERSONAS-AND-RULES.md` | Adds **Fast path — one prompt** at top of How to install. Explains why this is opt-in. |
| `ARCHITECTURE.md` | New **Install scope: skills + service, not personas** subsection under Distribution explaining the speed + decoupling rationale. |
| `docs/TEST-PLAN.md` | T1 reorganized: T1.4 verifies regime check works in default tone (no persona routing needed), T1.5 is the optional persona/rule install. T3.3 verifies re-runs preserve user-owned personas/rules untouched. Updated "Last reviewed" footer. |
| `skills/clarion-setup/scripts/setup.py` | **No changes** — already does the right thing. |

## Companion Zo registry PR

A companion PR to `zocomputer/skills` carries:
1. The same updated `SKILL.md` to the registry mirror at `External/clarion-setup/SKILL.md`
2. Back-syncs PR #23's free-tier `reasoning_model` default in `External/clarion-setup/scripts/setup.py` — the registry was stale (still shipping subscriber-tier `zo:anthropic/claude-opus-4-7` as the default for fresh installs, despite the policy commitment in `ARCHITECTURE.md`)

## Test plan

- [ ] Read the updated `docs/TEST-PLAN.md` T1 sequence — confirm T1.1 → T1.6 hangs together
- [ ] Spot-check `README.md` Quick-start flow reads correctly
- [ ] Run pytest — all 50+ tests still pass on this branch (`uv run pytest tests/test_fundamentals.py tests/test_indexer_main.py tests/test_zo_client.py` → 58 passed)
- [ ] Once both this PR and the registry PR land, a fresh Zo install should complete the autonomous portion in ~30 seconds
- [ ] Verify existing users aren't disrupted: re-running `clarion-setup` does NOT touch their personas/rules (Step 4 + 5 removed → no `list_personas` / `list_rules` / `create_persona` / `create_rule` calls during re-run)

## Related

- Issue context: Anthea's chat transcript surfaced this; chat with the maintainer (2026-05-20) confirmed the architectural call.
- Companion: `zocomputer/skills` PR (link will be added after submission)
- PR #21 (single-prompt install) is now scoped to functional-only, not persona/rule layer
- PR #23 (free-tier policy + config.json wiring) — the registry-side sync of `setup.py` is included in the companion PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)