### PR TITLE
Phase 0: detect pointer-only 10-K sections (issue #26)

### DIFF
--- a/lib/ai_buffett_zo/secrag/search.py
+++ b/lib/ai_buffett_zo/secrag/search.py
@@ -62,6 +62,12 @@ class SearchHit:
     snippet: short excerpt of `text` around the first matched keyword.
     citation: human-readable, e.g. "NVDA 10-K filed 2026-02-21 → risk_factors".
     path: e.g. "risk_factors" or "risk_factors/chunk2"
+
+    is_pointer_only + pointer_target: True when the hit came from a section
+    that incorporates substantive content by reference (Items 10-14 → DEF 14A,
+    Items 7-8 → Annual Report). Callers (e.g. the eval skill) can surface
+    "this section is a pointer; substantive content lives in [target]" instead
+    of treating the snippet as fact.
     """
 
     ticker: str
@@ -74,6 +80,8 @@ class SearchHit:
     snippet: str
     score: float
     citation: str
+    is_pointer_only: bool = False
+    pointer_target: str | None = None
 
 
 def search(
@@ -327,6 +335,8 @@ def _hit_from_entry(
         snippet=snippet,
         score=score,
         citation=_citation(meta.ticker, meta.form, meta.filed.isoformat(), path),
+        is_pointer_only=section.is_pointer_only,
+        pointer_target=section.pointer_target,
     )
 
 
@@ -371,6 +381,8 @@ def _score_section(
         snippet=snippet,
         score=score,
         citation=_citation(meta.ticker, meta.form, meta.filed.isoformat(), section.label),
+        is_pointer_only=section.is_pointer_only,
+        pointer_target=section.pointer_target,
     )
 
 
@@ -398,6 +410,8 @@ def _score_chunk(
         snippet=snippet,
         score=score,
         citation=_citation(meta.ticker, meta.form, meta.filed.isoformat(), path),
+        is_pointer_only=section.is_pointer_only,
+        pointer_target=section.pointer_target,
     )
 
 

--- a/lib/ai_buffett_zo/secrag/sections.py
+++ b/lib/ai_buffett_zo/secrag/sections.py
@@ -120,8 +120,23 @@ POINTER_TARGET_DEF14A_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Pointer-language markers used to distinguish "real but unrecognized pointer"
+# from "parser-extraction bug." Short curated 10-K sections almost always
+# contain at least one of these tokens when they're a genuine pointer
+# (canonical "incorporated by reference", varied "Refer to...", "see our
+# Consolidated...", "is set forth in...", or even bare "Pages 56-108"). Short
+# sections WITHOUT any of these tokens are typically parser bugs — TOC
+# fragments, orphan whitespace, the `ANY_ITEM_HEADER` regex anchoring on a
+# table-of-contents line instead of the body. Phase 2 should skip recovery on
+# those; the underlying extractor regex is tracked separately.
+POINTER_LANGUAGE_RE = re.compile(
+    r"\brefer\b|\bsee\b|\bincorporat(?:ed|ing)\b|\bset\s+forth\b"
+    r"|\binformation\s+required\b|\bpages?\s+\d",
+    re.IGNORECASE,
+)
+
 # Threshold for "section body is too short to be substantive 10-K content."
-# Real Items 7-8 pointers in IBM/KO/NVDA/INTC measure 177-499 chars; real
+# Real Items 7-8 pointers in IBM/KO/NVDA/INTC measure 37-499 chars; real
 # legitimate-content sections in the same dataset start at ~540 chars (MU
 # mdna). 500 is the natural cut-line.
 POINTER_BODY_MAX_CHARS = 500
@@ -134,24 +149,37 @@ def _detect_pointer(body: str) -> tuple[bool, str | None]:
     much to use as a gate ("Refer to...", "see our Consolidated...", "is set
     forth in...", page-only references). Curated 10-K sections are normally
     multi-page; bodies under ``POINTER_BODY_MAX_CHARS`` (500) are almost
-    always either pointers or TOC-capture parser bugs — both worth flagging
-    for downstream recovery.
+    always either pointers or parser-extraction bugs.
 
-    The phrase regexes are used purely for classification: once a section is
-    flagged short, they decide the most likely target document (Annual
-    Report / Exhibit 13 in same doc, separate DEF 14A, or unknown).
+    Classification distinguishes the two so Phase 2 can act differently:
 
-    Returns ``(is_pointer_only, pointer_target)``:
+    - ``"annual_report_same_doc"`` — body mentions Annual Report to
+      Stockholders or Exhibit 13 (Pattern B: companion-document recovery
+      via FilingSummary.xml + R-files).
+    - ``"def14a"`` — body mentions Proxy Statement or Schedule 14A
+      (Pattern A: companion DEF 14A auto-enqueue, handled by Phase 1).
+    - ``"unknown"`` — body has at least one pointer-language marker but
+      doesn't match a specific target document. Phase 2 should still
+      attempt FilingSummary recovery; most "unknown" cases turn out to
+      be same-doc pointers using varied phrasing.
+    - ``"parser_bug"`` — body has NO pointer-language markers at all.
+      These are TOC fragments, orphan whitespace, or other extractor
+      artifacts (e.g. PWR business="and" at 3 chars). Phase 2 should
+      skip recovery; the underlying extractor regex needs separate fix.
 
-    - ``is_pointer_only``: True iff body is shorter than the threshold.
-    - ``pointer_target``: ``"annual_report_same_doc"``, ``"def14a"``,
-      ``"unknown"``, or ``None`` when ``is_pointer_only`` is False.
+    Returns ``(is_pointer_only, pointer_target)``. ``is_pointer_only`` is
+    True iff body is shorter than the threshold; ``pointer_target`` is one
+    of the four strings above or ``None`` when not a pointer.
 
     Only call this on curated 10-K/10-Q sections. Generic extraction (DEF
     14A, Form 4, etc.) has legitimate short sections and shouldn't be flagged.
     """
     if len(body) >= POINTER_BODY_MAX_CHARS:
         return False, None
+    # Short body without any pointer-language markers → parser bug. Don't
+    # let Phase 2 try to "recover" content that was never there.
+    if not POINTER_LANGUAGE_RE.search(body):
+        return True, "parser_bug"
     if POINTER_TARGET_ANNUAL_REPORT_RE.search(body):
         return True, "annual_report_same_doc"
     if POINTER_TARGET_DEF14A_RE.search(body):

--- a/lib/ai_buffett_zo/secrag/sections.py
+++ b/lib/ai_buffett_zo/secrag/sections.py
@@ -40,6 +40,11 @@ class Section:
     - A canonical 10-K name: "business" | "risk_factors" | "mdna" | "financial_statements"
     - A slug derived from the heading title (for generic extraction):
       "prospectus-summary" | "form-4" | "executive-compensation" | etc.
+
+    Pointer-only sections (those that incorporate substantive content by
+    reference instead of containing it inline) are flagged so downstream
+    consumers can either follow the pointer or surface the gap to the user.
+    See `_detect_pointer` for the heuristic.
     """
 
     label: str
@@ -47,6 +52,8 @@ class Section:
     text: str           # body text under this heading
     char_start: int     # offset in the normalized doc
     char_end: int
+    is_pointer_only: bool = False         # True when body is just an "incorporated by reference" pointer
+    pointer_target: str | None = None     # "def14a" | "annual_report_same_doc" | "unknown" | None
 
 
 # ---- Curated 10-K / 10-Q paths --------------------------------------------
@@ -77,6 +84,79 @@ ANY_ITEM_HEADER = re.compile(
     r"\bitem\s*\d+[a-z]?\b[\.\s\-:–—]",
     re.IGNORECASE,
 )
+
+# ---- Pointer-section detection --------------------------------------------
+#
+# Some 10-K sections (especially Items 7-8 and 10-14) are short pointers that
+# direct the reader to substantive content elsewhere — sometimes in a
+# companion DEF 14A proxy filing, sometimes later in the same primary 10-K doc
+# (as "Exhibit 13" or "Annual Report"), sometimes just a page reference like
+# "Pages 56-108".
+#
+# **Detection is length-only for curated 10-K/10-Q sections** (Items 1, 1A, 7,
+# 8). Real-data sweep against 30 indexed 10-Ks (2026-05-20) showed pointer
+# language is wildly varied — only 3 of 11 short pointers used the
+# "incorporated by reference" phrasing. The others said "Refer to...", "see
+# our Consolidated Financial Statements", "is set forth in...", or just page
+# numbers. Length is the only reliable signal because curated 10-K sections
+# are normally multi-page; a short body is almost always a pointer or a
+# TOC-capture parser bug (both useful to flag for downstream recovery).
+#
+# Phrase patterns below are used purely for **classification** — once a
+# section is flagged short, the patterns decide what kind of pointer it
+# probably is so Phase 1/2 can pick the right recovery strategy. Phrase
+# matches don't gate detection.
+
+# Distinguishes which document the pointer points to. Annual-Report references
+# are checked first because Pattern B (Items 7/8 → same-doc continuation) is
+# higher severity than Pattern A (Items 10-14 → companion DEF 14A); when both
+# match, the more-severe target wins.
+POINTER_TARGET_ANNUAL_REPORT_RE = re.compile(
+    r"annual\s+report\s+to\s+(?:stockholders|shareholders)|exhibit\s+13\b",
+    re.IGNORECASE,
+)
+POINTER_TARGET_DEF14A_RE = re.compile(
+    r"proxy\s+statement|schedule\s+14a|def\s*14a",
+    re.IGNORECASE,
+)
+
+# Threshold for "section body is too short to be substantive 10-K content."
+# Real Items 7-8 pointers in IBM/KO/NVDA/INTC measure 177-499 chars; real
+# legitimate-content sections in the same dataset start at ~540 chars (MU
+# mdna). 500 is the natural cut-line.
+POINTER_BODY_MAX_CHARS = 500
+
+
+def _detect_pointer(body: str) -> tuple[bool, str | None]:
+    """Classify a curated 10-K section body as pointer-only or substantive.
+
+    **Detection is length-only.** Pointer phrasing in real 10-Ks varies too
+    much to use as a gate ("Refer to...", "see our Consolidated...", "is set
+    forth in...", page-only references). Curated 10-K sections are normally
+    multi-page; bodies under ``POINTER_BODY_MAX_CHARS`` (500) are almost
+    always either pointers or TOC-capture parser bugs — both worth flagging
+    for downstream recovery.
+
+    The phrase regexes are used purely for classification: once a section is
+    flagged short, they decide the most likely target document (Annual
+    Report / Exhibit 13 in same doc, separate DEF 14A, or unknown).
+
+    Returns ``(is_pointer_only, pointer_target)``:
+
+    - ``is_pointer_only``: True iff body is shorter than the threshold.
+    - ``pointer_target``: ``"annual_report_same_doc"``, ``"def14a"``,
+      ``"unknown"``, or ``None`` when ``is_pointer_only`` is False.
+
+    Only call this on curated 10-K/10-Q sections. Generic extraction (DEF
+    14A, Form 4, etc.) has legitimate short sections and shouldn't be flagged.
+    """
+    if len(body) >= POINTER_BODY_MAX_CHARS:
+        return False, None
+    if POINTER_TARGET_ANNUAL_REPORT_RE.search(body):
+        return True, "annual_report_same_doc"
+    if POINTER_TARGET_DEF14A_RE.search(body):
+        return True, "def14a"
+    return True, "unknown"
 
 # Form types that use the curated 10-K extraction path. All other forms use
 # generic extraction.
@@ -171,6 +251,7 @@ def extract_sections_from_text(text: str) -> list[Section]:
             end = _find_section_end(text, after=m.end())
         body = text[m.end():end].strip()
         title_line = text[m.start():m.end()].strip()
+        is_pointer, target = _detect_pointer(body)
         sections.append(
             Section(
                 label=label,
@@ -178,6 +259,8 @@ def extract_sections_from_text(text: str) -> list[Section]:
                 text=body,
                 char_start=start,
                 char_end=end,
+                is_pointer_only=is_pointer,
+                pointer_target=target,
             )
         )
     return sections
@@ -217,7 +300,10 @@ def _split_markdown_top_level(markdown: str) -> list[Section]:
     """Split markdown on its top-level (shallowest) heading level."""
     matches = list(_HEADING_RE.finditer(markdown))
     if not matches:
-        # No headings — return one section with the whole text
+        # No headings — return one section with the whole text. Pointer
+        # detection skipped on the generic path; DEF 14A / Form 4 / 8-K
+        # have legitimate short sections that the length-only detector
+        # would over-flag.
         return [
             Section(
                 label="filing-content",
@@ -240,6 +326,9 @@ def _split_markdown_top_level(markdown: str) -> list[Section]:
         body = markdown[start:end].strip()
         if not title and not body:
             continue
+        # Pointer detection deliberately skipped on the generic path — see the
+        # docstring on `_detect_pointer`. Curated 10-K/10-Q extraction (above)
+        # is the only call site.
         sections.append(
             Section(
                 label=_slugify(title),

--- a/lib/ai_buffett_zo/secrag/storage.py
+++ b/lib/ai_buffett_zo/secrag/storage.py
@@ -141,6 +141,8 @@ def _section_to_dict(s: SectionNode) -> dict[str, Any]:
         "summary": s.summary,
         "summary_data": s.summary_data,
         "chunks": [asdict(c) for c in s.chunks],
+        "is_pointer_only": s.is_pointer_only,
+        "pointer_target": s.pointer_target,
     }
 
 
@@ -172,6 +174,10 @@ def _section_from_dict(d: dict[str, Any]) -> SectionNode:
         summary=d["summary"],
         summary_data=d.get("summary_data", {}),
         chunks=[_chunk_from_dict(c) for c in d.get("chunks", [])],
+        # Older indexed trees (pre-PR #26 fix) don't have these fields — default
+        # to "substantive" so legacy data continues to behave as before.
+        is_pointer_only=d.get("is_pointer_only", False),
+        pointer_target=d.get("pointer_target"),
     )
 
 

--- a/lib/ai_buffett_zo/secrag/tree.py
+++ b/lib/ai_buffett_zo/secrag/tree.py
@@ -43,7 +43,13 @@ class ChunkNode:
 
 @dataclass
 class SectionNode:
-    """One curated section. `chunks` is empty when section fit under the budget."""
+    """One curated section. `chunks` is empty when section fit under the budget.
+
+    `is_pointer_only` + `pointer_target` carry forward from the source
+    `Section` so downstream consumers (search results, follow-up fixes) can
+    tell whether the section's text is substantive or a pointer to content
+    living elsewhere.
+    """
 
     label: str
     title: str
@@ -51,6 +57,8 @@ class SectionNode:
     summary: str
     summary_data: dict[str, Any]
     chunks: list[ChunkNode] = field(default_factory=list)
+    is_pointer_only: bool = False
+    pointer_target: str | None = None
 
 
 @dataclass(frozen=True)
@@ -86,6 +94,8 @@ def build_raw_tree(metadata: FilingMetadata, sections: list[Section]) -> FilingT
             summary="",
             summary_data={},
             chunks=[],
+            is_pointer_only=s.is_pointer_only,
+            pointer_target=s.pointer_target,
         )
         for s in sections
     ]
@@ -159,6 +169,8 @@ class TreeBuilder:
                 summary=data.get("one_sentence_summary", ""),
                 summary_data=data,
                 chunks=[],
+                is_pointer_only=section.is_pointer_only,
+                pointer_target=section.pointer_target,
             )
 
         chunks_text = _chunk_text(section.text, target_tokens=self.max_chunk_tokens)
@@ -182,6 +194,8 @@ class TreeBuilder:
             summary=synth_data.get("one_sentence_summary", ""),
             summary_data=synth_data,
             chunks=chunk_nodes,
+            is_pointer_only=section.is_pointer_only,
+            pointer_target=section.pointer_target,
         )
 
     def _summarize_text(

--- a/tests/test_secrag_sections.py
+++ b/tests/test_secrag_sections.py
@@ -193,12 +193,12 @@ SUBSTANTIVE_RISK_FACTORS = (
         (KO_ITEM11_POINTER, True, "def14a"),
         (IBM_ITEM8_POINTER, True, "annual_report_same_doc"),
         (IBM_ITEM7_POINTER, True, "annual_report_same_doc"),
-        # Varied phrasings the Zo found in real 10-Ks (length-only detection
-        # catches all of these; classification falls back to "unknown" when
-        # neither annual-report nor def14a patterns match)
-        (KO_ITEM8_POINTER_VARIED, True, "unknown"),
-        (NVDA_ITEM8_POINTER_VARIED, True, "unknown"),
-        (INTC_ITEM8_POINTER_TERSE, True, "unknown"),
+        # Varied phrasings the canonical Zo found in real 10-Ks. Length-only
+        # detection catches all of these; classification keys on what
+        # pointer-language tokens are present.
+        (KO_ITEM8_POINTER_VARIED, True, "unknown"),       # "Refer to..."
+        (NVDA_ITEM8_POINTER_VARIED, True, "unknown"),     # "set forth in..."
+        (INTC_ITEM8_POINTER_TERSE, True, "unknown"),      # "Pages 56-108"
         # Long substantive content stays clean even if it mentions
         # "incorporated by reference" in passing
         (SUBSTANTIVE_RISK_FACTORS, False, None),
@@ -209,10 +209,16 @@ SUBSTANTIVE_RISK_FACTORS = (
             False,
             None,
         ),
-        # Edge case: "Not applicable" is also short → flagged as unknown.
-        # This is the intentional trade-off: a 10-K with literally just "Not
-        # applicable" in a curated section is broken either way.
-        ("Not applicable.", True, "unknown"),
+        # Parser-bug cases the canonical Zo found in real 10-Ks: short
+        # extractor outputs with no pointer-language tokens. These are TOC
+        # fragments / orphan whitespace, not real pointers — Phase 2 should
+        # skip recovery on them.
+        ("and", True, "parser_bug"),                                # PWR business=3 chars
+        ("3\n\nInformation about our Executive Officers\n\n14", True, "parser_bug"),  # MSFT TOC
+        # "Not applicable" — also short, no pointer language → parser bug.
+        # A 10-K with literally "Not applicable" in a curated section is
+        # broken either way; flagging it as parser_bug is the right behavior.
+        ("Not applicable.", True, "parser_bug"),
     ],
 )
 def test_detect_pointer_classifies_pointer_and_target(body, expected_pointer, expected_target) -> None:

--- a/tests/test_secrag_sections.py
+++ b/tests/test_secrag_sections.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import pytest
+
 from ai_buffett_zo.secrag import (
     extract_sections,
     extract_sections_from_text,
     html_to_text,
 )
+from ai_buffett_zo.secrag.sections import _detect_pointer
 
 
 SAMPLE_10K_HTML = """
@@ -123,3 +126,129 @@ def test_section_offsets_in_doc_order() -> None:
     sections = extract_sections(SAMPLE_10K_HTML)
     starts = [s.char_start for s in sections]
     assert starts == sorted(starts)
+
+
+# ---- Pointer detection (issue #26) ----------------------------------------
+
+
+# Paraphrased sentences from real 10-K filings. Lengths match live
+# measurements on cis.zo.computer's indexed filings (2026-05-20):
+# - IBM/RKLB Item 7/8 pointers: 220-376 chars (canonical "incorporated by reference" phrasing)
+# - KO/NVDA/INTC/FSLR/NFLX/TSLA/DECK Item 8 pointers: 37-356 chars (varied phrasing — "Refer to...", "set forth in...", page numbers)
+# - Real legitimate substantive sections in the same dataset start at ~540 chars
+# Detection is length-only; phrase patterns only classify the target.
+
+
+KO_ITEM11_POINTER = (
+    "The information required by this Item is incorporated herein by reference "
+    "to the information set forth under the captions 'Executive Compensation' "
+    "and 'Compensation Discussion and Analysis' in the Company's definitive "
+    "Proxy Statement on Schedule 14A for the 2025 Annual Meeting of Shareowners."
+)
+
+IBM_ITEM8_POINTER = (
+    "The financial statements and supplementary data required by this Item are "
+    "included in the Annual Report to Stockholders filed as Exhibit 13 to this "
+    "Form 10-K and are incorporated herein by reference."
+)
+
+IBM_ITEM7_POINTER = (
+    "The information required by Item 7 is included in the Annual Report to "
+    "Stockholders filed as Exhibit 13 of this Form 10-K, which is incorporated "
+    "herein by reference."
+)
+
+# KO uses "Refer to..." phrasing — no incorporation-by-reference language
+KO_ITEM8_POINTER_VARIED = (
+    "Refer to 'Financial Statements and Supplementary Data' included in this "
+    "report. The consolidated financial statements and accompanying notes "
+    "begin on page F-1 of this Form 10-K."
+)
+
+# NVDA uses "is set forth in" phrasing — also no incorporation phrase
+NVDA_ITEM8_POINTER_VARIED = (
+    "The information required by this Item is set forth in our Consolidated "
+    "Financial Statements and accompanying notes."
+)
+
+# INTC's Item 8 is essentially a page reference
+INTC_ITEM8_POINTER_TERSE = "and Supplementary Data Pages 56-108"
+
+SUBSTANTIVE_RISK_FACTORS = (
+    "Our business is concentrated in a small number of high-value contracts; "
+    "the loss of any one of them could materially impact revenue. "
+    "Approximately 35 percent of total revenue in fiscal 2024 came from our "
+    "top three customers. Our supply chain depends on a single fabrication "
+    "partner for advanced-node manufacturing, exposing us to disruption from "
+    "geopolitical events, natural disasters, or capacity constraints at that "
+    "partner. We do not currently have second-source agreements in place for "
+    "our highest-volume products. " * 2  # >500 chars total
+)
+
+
+@pytest.mark.parametrize(
+    ("body", "expected_pointer", "expected_target"),
+    [
+        # Canonical IBM/KO cases with "incorporated by reference" phrasing
+        (KO_ITEM11_POINTER, True, "def14a"),
+        (IBM_ITEM8_POINTER, True, "annual_report_same_doc"),
+        (IBM_ITEM7_POINTER, True, "annual_report_same_doc"),
+        # Varied phrasings the Zo found in real 10-Ks (length-only detection
+        # catches all of these; classification falls back to "unknown" when
+        # neither annual-report nor def14a patterns match)
+        (KO_ITEM8_POINTER_VARIED, True, "unknown"),
+        (NVDA_ITEM8_POINTER_VARIED, True, "unknown"),
+        (INTC_ITEM8_POINTER_TERSE, True, "unknown"),
+        # Long substantive content stays clean even if it mentions
+        # "incorporated by reference" in passing
+        (SUBSTANTIVE_RISK_FACTORS, False, None),
+        (
+            "Our debt agreements contain financial covenants. "
+            "The risk-weighted assets calculation methodology is incorporated "
+            "herein by reference to the Basel III framework. " + "x" * 600,
+            False,
+            None,
+        ),
+        # Edge case: "Not applicable" is also short → flagged as unknown.
+        # This is the intentional trade-off: a 10-K with literally just "Not
+        # applicable" in a curated section is broken either way.
+        ("Not applicable.", True, "unknown"),
+    ],
+)
+def test_detect_pointer_classifies_pointer_and_target(body, expected_pointer, expected_target) -> None:
+    is_pointer, target = _detect_pointer(body)
+    assert is_pointer is expected_pointer
+    assert target == expected_target
+
+
+def test_pointer_detection_propagates_to_extracted_section() -> None:
+    """End-to-end: a curated 10-K extraction surfaces is_pointer_only on the right section."""
+    text = (
+        "Item 1. Business\n"
+        + "We sell things. " * 80  # substantive
+        + "\n\n"
+        + "Item 1A. Risk Factors\n"
+        + "Things could go wrong. " * 80  # substantive
+        + "\n\n"
+        + "Item 7. Management's Discussion and Analysis\n"
+        + IBM_ITEM7_POINTER
+        + "\n\n"
+        + "Item 8. Financial Statements\n"
+        + IBM_ITEM8_POINTER
+        + "\n\n"
+        + "Item 9. Changes in Accountants\nNone.\n"
+    )
+    sections = extract_sections_from_text(text)
+    by_label = {s.label: s for s in sections}
+
+    # Pointer sections flagged correctly
+    assert by_label["mdna"].is_pointer_only is True
+    assert by_label["mdna"].pointer_target == "annual_report_same_doc"
+    assert by_label["financial_statements"].is_pointer_only is True
+    assert by_label["financial_statements"].pointer_target == "annual_report_same_doc"
+
+    # Substantive sections stay clean
+    assert by_label["business"].is_pointer_only is False
+    assert by_label["business"].pointer_target is None
+    assert by_label["risk_factors"].is_pointer_only is False
+    assert by_label["risk_factors"].pointer_target is None


### PR DESCRIPTION
## Summary

First of three planned PRs for [issue #26](https://github.com/jingerzz/clarion-intelligence-system/issues/26) (SEC indexer doesn't follow "incorporated by reference" pointers). This PR ships **Phase 0 — detection and classification only**. Recovery (Phase 2) and DEF 14A auto-enqueue (Phase 1) follow in separate PRs.

Phase 0 by itself adds visibility into the problem: search results and indexed trees now carry an `is_pointer_only` flag + `pointer_target` classification, so consumers can tell when a section's text is a pointer vs. substantive content. The eval pipeline doesn't change behavior yet — that comes with Phase 2.

## Why this lands first

Phase 0 is a metadata-only change (no behavior change for existing users) that:
- Lets the canonical Zo re-index existing filings and start seeing real pointer flags on indexed data
- De-risks the Phase 2 PR by isolating the detection-regex calibration from the bigger fetcher/cache work
- Adds the foundation the FilingSummary.xml recovery approach (Phase 2) depends on

The canonical Zo has already real-data-validated this detection layer against 30 indexed 10-Ks ([review comment](https://github.com/jingerzz/clarion-intelligence-system/issues/26#issuecomment-4512593431) — \"Phase 0 review — ✅ ship\").

## Design

**Detection is length-only** for curated 10-K/10-Q sections (Items 1, 1A, 7, 8). Real-data sweep showed pointer phrasing varies too much for a phrase gate:
- Only 3 of 11 real pointers use canonical \"incorporated by reference\"
- KO uses \"Refer to...\", NVDA uses \"set forth in...\", INTC uses bare \"Pages 56-108\"
- Length is the only reliable signal because curated 10-K sections are normally multi-page; real legitimate-content sections in the dataset start at ~540 chars

`POINTER_BODY_MAX_CHARS = 500` is the cut-line. Below it, the section is flagged.

**Classification distinguishes four targets** so Phase 1/2 can act differently per case:

| Target | When | Phase 2 action |
|---|---|---|
| `annual_report_same_doc` | Body mentions \"Annual Report to Stockholders\" or \"Exhibit 13\" | FilingSummary recovery |
| `def14a` | Body mentions \"Proxy Statement\" or \"Schedule 14A\" | Phase 1 auto-enqueue companion DEF 14A |
| `parser_bug` | Body has NO pointer-language tokens (\"refer\" / \"see\" / \"incorporated\" / \"set forth\" / \"information required\" / page references) | Skip — these are extractor bugs, not real pointers |
| `unknown` | Body has pointer-language tokens but doesn't match a specific target | FilingSummary recovery (most cases turn out to be same-doc) |

**Generic extraction path (DEF 14A, Form 4, 8-K) skips detection entirely** — those forms have legitimate short sections that length-only would over-flag.

## Files changed

| File | Change |
|---|---|
| `lib/ai_buffett_zo/secrag/sections.py` | New `_detect_pointer()`, `POINTER_LANGUAGE_RE`, `POINTER_TARGET_ANNUAL_REPORT_RE`, `POINTER_TARGET_DEF14A_RE`, `POINTER_BODY_MAX_CHARS`. New `is_pointer_only` + `pointer_target` fields on `Section` dataclass. Called in `extract_sections_from_text` (curated path only). |
| `lib/ai_buffett_zo/secrag/tree.py` | New fields on `SectionNode`, propagated from `Section` in `build_raw_tree` and `TreeBuilder._build_section`. |
| `lib/ai_buffett_zo/secrag/storage.py` | Persist new fields in `_section_to_dict` / `_section_from_dict`. Old trees without the fields load with safe defaults (`False` / `None`). |
| `lib/ai_buffett_zo/secrag/search.py` | New `is_pointer_only` + `pointer_target` fields on `SearchHit`, populated from `SectionNode` at all three construction sites. Lets the eval skill warn users when a hit is from pointer text. |
| `tests/test_secrag_sections.py` | New `_detect_pointer` parametrized test covering all four classification paths + substantive negative + long-body-with-passing-mention negative + parser-bug cases the canonical Zo found (PWR \"and\", MSFT TOC fragment, \"Not applicable\"). |

## Test plan

- [x] All 649 existing tests pass on this branch
- [x] Ruff clean
- [x] New parametrized test covers 11 cases across all four classification paths
- [x] Canonical Zo real-data validation against 30 indexed 10-Ks ([comment](https://github.com/jingerzz/clarion-intelligence-system/issues/26#issuecomment-4512593431)): 17 pointer sections flagged, no false positives on substantive content, parser-bug heuristic correctly distinguishes PWR/MSFT extractor noise from real pointers
- [ ] After merge: re-run `clarion-setup` on the canonical Zo, re-index IBM/KO/NVDA, confirm `tree.sections[].is_pointer_only` flags appear

## Follow-ups (separate PRs)

- **Phase 2:** FilingSummary.xml + R-file fetch for `annual_report_same_doc` / `unknown` targets (the actual user-visible fix for IBM evaluations)
- **Phase 1:** DEF 14A auto-enqueue for `def14a` targets (only RKLB observed in the 30-filing sweep, so lower urgency)
- **Section extractor TOC-bug fix:** tighten `ANY_ITEM_HEADER` regex to skip TOC entries (the underlying cause of \"parser_bug\" cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)