### PR TITLE
fix: TOC-aware curated extraction with smart retry (issue #32)

### DIFF
--- a/lib/ai_buffett_zo/secrag/sections.py
+++ b/lib/ai_buffett_zo/secrag/sections.py
@@ -78,6 +78,29 @@ ANY_ITEM_HEADER = re.compile(
     re.IGNORECASE,
 )
 
+# Anchor used by the TOC-aware retry path (issue #32). The body of a 10-K
+# always starts with "PART I" right after the table of contents. When the
+# first-pass curated regex matches only TOC entries, we re-search starting
+# from the first PART I occurrence to find the actual body headings.
+_PART_ONE_ANCHOR_RE = re.compile(r"^\s*PART\s+I\b", re.IGNORECASE | re.MULTILINE)
+
+# Body bodies that consist entirely of separators + digits are page-range
+# strings between TOC entries (e.g. "8 - 24 , 80 - 85 , 88 - 97") — never
+# a real Item 1 / 7 / 8 body. Anchored to the full string (after .strip()).
+_TOC_BODY_PURE_RE = re.compile(r"^[\s\.\-–—,;\d]+$")
+
+# A page range like "8 - 24" or "103-150". TOC captures often have leftover
+# prose from the regex match itself (e.g. "and Supplementary Data 103 - 150"
+# on SYF's Item 8 because the regex stops right after "Financial Statements")
+# so the pure-digit check above isn't enough on its own. One page-range
+# pattern in a short body is a strong TOC signal; two or more is decisive.
+_TOC_PAGE_RANGE_RE = re.compile(r"\b\d+\s*[-–]\s*\d+\b")
+
+# Below this density threshold, the body has too much prose to plausibly be
+# a TOC fragment. Backup heuristic for cases that don't match the patterns
+# above (e.g. terse "Pages 56" without a range).
+_TOC_DIGIT_DENSITY_THRESHOLD = 0.4
+
 # Form types that use the curated 10-K extraction path. All other forms use
 # generic extraction.
 CURATED_FORMS: frozenset[str] = frozenset({"10-K", "10-Q", "10-K/A", "10-Q/A"})
@@ -151,10 +174,61 @@ def extract_sections(html: str) -> list[Section]:
 
 
 def extract_sections_from_text(text: str) -> list[Section]:
-    """Curated extraction from pre-normalized text. See `extract_sections`."""
+    """Curated extraction from pre-normalized text. See `extract_sections`.
+
+    Two-pass with TOC-aware retry (issue #32):
+
+    1. **First pass** — run the curated regex against the whole document.
+       For typical 10-Ks this finds the body headings directly and we
+       return immediately.
+
+    2. **TOC detection** — if every captured section's body looks like a
+       TOC entry (mostly page numbers / dashes / commas), the regex
+       anchored on the table of contents instead of the actual section
+       bodies. Common pathology in 10-Ks where the body uses HTML
+       structure the regex can't see (e.g., split `<b>Item 1.</b>` +
+       `<b>Description of Business</b>` on separate lines, or section
+       names that include extra words like "Description of" or "Our").
+
+    3. **Smart retry** — re-run the regex starting from the first
+       ``PART I`` heading. PART I is the canonical landmark for the
+       10-K body start; everything before it is cover page + TOC.
+
+    4. **Fallback signal** — if the retry also captures only TOC-shaped
+       bodies (or no matches at all), return ``[]``. The caller
+       (``extract_sections_for_form``) treats an empty result as
+       extraction failure and falls back to generic extraction.
+    """
+    sections = _curated_pass(text, search_start=0)
+
+    # First-pass success: at least one body is substantive
+    if not _all_toc_shaped(sections):
+        return sections
+
+    # All TOC-shaped: try once more from after the PART I anchor
+    anchor = _PART_ONE_ANCHOR_RE.search(text)
+    if anchor is not None:
+        retry = _curated_pass(text, search_start=anchor.end())
+        if retry and not _all_toc_shaped(retry):
+            return retry
+
+    # Retry failed (or there was no PART I anchor): signal failure so the
+    # caller falls back to generic extraction.
+    return []
+
+
+def _curated_pass(text: str, *, search_start: int) -> list[Section]:
+    """One pass of the curated regex matching, starting at ``search_start``.
+
+    Preserves the original "last match per label wins" behavior so that
+    when a body heading appears multiple times in the doc (e.g., TOC +
+    body), we pick the latest one — which is typically the body. The
+    ``search_start`` parameter lets the caller skip past a known-TOC
+    region entirely for the retry pass.
+    """
     last_match: dict[str, re.Match[str]] = {}
     for label, pattern in CURATED_SECTIONS.items():
-        for m in pattern.finditer(text):
+        for m in pattern.finditer(text, pos=search_start):
             last_match[label] = m
 
     if not last_match:
@@ -181,6 +255,59 @@ def extract_sections_from_text(text: str) -> list[Section]:
             )
         )
     return sections
+
+
+def _all_toc_shaped(sections: list[Section]) -> bool:
+    """True when ``sections`` is non-empty AND every body is TOC-shaped.
+
+    Empty list returns False (not "all TOC", just "nothing extracted").
+    Caller distinguishes "no match" from "match but garbage" by the
+    section list emptiness vs. this predicate.
+    """
+    if not sections:
+        return False
+    return all(_is_toc_shaped(s.text) for s in sections)
+
+
+def _is_toc_shaped(body: str) -> bool:
+    """Does this section body look like a captured TOC entry?
+
+    A real Item 1 / 1A / 7 / 8 section in a 10-K is multi-page
+    substantive prose. A TOC-region capture pulls in page references
+    only (e.g., ``"8 - 24 , 80 - 85 , 88 - 97"`` or
+    ``"and Supplementary Data 103 - 150"``). We detect via four signals,
+    layered weakest-to-strongest:
+
+    1. **Pure separators + digits.** Trimmed body is only whitespace,
+       dots, dashes, commas, semicolons, digits → definitely TOC.
+    2. **One page-range pattern in a short body** (< 100 chars). One
+       ``\\d+ - \\d+`` is a strong TOC signal when there's no other
+       substance.
+    3. **Two or more page-range patterns.** Multiple page references
+       in one body → unambiguously TOC.
+    4. **High digit density in the head.** Fallback for terse cases.
+
+    Long bodies (> 500 chars) are always considered substantive —
+    real TOC fragments are bounded by the next Item header in the
+    same TOC, so they're always short.
+    """
+    if len(body) > 500:
+        return False
+    sample = body.strip()
+    if not sample:
+        return False
+    if _TOC_BODY_PURE_RE.match(sample):
+        return True
+    page_ranges = _TOC_PAGE_RANGE_RE.findall(sample)
+    if len(page_ranges) >= 2:
+        return True
+    if len(page_ranges) >= 1 and len(sample) < 100:
+        return True
+    head = sample[:100].replace(" ", "").replace("\n", "")
+    if not head:
+        return False
+    digit_pct = sum(1 for c in head if c.isdigit()) / len(head)
+    return digit_pct > _TOC_DIGIT_DENSITY_THRESHOLD
 
 
 def _find_section_end(text: str, *, after: int) -> int:

--- a/tests/test_secrag_sections.py
+++ b/tests/test_secrag_sections.py
@@ -7,6 +7,7 @@ from ai_buffett_zo.secrag import (
     extract_sections_from_text,
     html_to_text,
 )
+from ai_buffett_zo.secrag.sections import _is_toc_shaped, extract_sections_for_form
 
 
 SAMPLE_10K_HTML = """
@@ -123,3 +124,164 @@ def test_section_offsets_in_doc_order() -> None:
     sections = extract_sections(SAMPLE_10K_HTML)
     starts = [s.char_start for s in sections]
     assert starts == sorted(starts)
+
+
+# ---- TOC-aware extraction (issue #32) -------------------------------------
+
+
+# Real-data sample: SYF 10-K (paraphrased structure). The TOC at the start
+# matches the curated regex for "Item 1. Business" etc., but the body uses
+# a different heading format that the regex doesn't catch (e.g., the body
+# heading reads "Item 1. Description of Business" — extra "Description of"
+# word that doesn't fit the `[\.\s\-:–—]*business\b` regex). Without the
+# TOC-aware retry, the curated extractor returns sections whose body is
+# just page references.
+
+_SYF_STYLE_TOC_TEXT = (
+    "SYNCHRONY FINANCIAL\n"
+    "\n"
+    "Form 10-K\n"
+    "\n"
+    "Table of Contents\n"
+    "\n"
+    "Item 1. Business 8 - 24\n"
+    "Item 1A. Risk Factors 25 - 50\n"
+    "Item 7. Management's Discussion and Analysis 53 - 80\n"
+    "Item 8. Financial Statements and Supplementary Data 80 - 85, 88 - 97\n"
+    "\n"
+    # Just the TOC — no PART I, no body headings the regex can find.
+    # This is the pathological case where smart retry has no anchor to use.
+)
+
+_SYF_STYLE_WITH_PART_I_AND_BODY = (
+    "SYNCHRONY FINANCIAL\n"
+    "\n"
+    "Form 10-K\n"
+    "\n"
+    "Table of Contents\n"
+    "\n"
+    "Item 1. Business 8 - 24\n"
+    "Item 1A. Risk Factors 25 - 50\n"
+    "Item 7. Management's Discussion and Analysis 53 - 80\n"
+    "Item 8. Financial Statements and Supplementary Data 80 - 85, 88 - 97\n"
+    "\n"
+    "PART I\n"
+    "\n"
+    "Item 1. Business\n"
+    + ("We are a premier consumer financial services company. " * 30) + "\n"
+    "\n"
+    "Item 1A. Risk Factors\n"
+    + ("Our business is subject to various risks and uncertainties. " * 30) + "\n"
+    "\n"
+    "Item 7. Management's Discussion and Analysis of Financial Condition\n"
+    + ("Revenue increased 8% year over year. " * 30) + "\n"
+    "\n"
+    "Item 8. Financial Statements and Supplementary Data\n"
+    + ("Total revenue: $18.5 billion. Net income: $3.2 billion. " * 30) + "\n"
+)
+
+
+# ---- _is_toc_shaped --------------------------------------------------------
+
+
+def test_is_toc_shaped_pure_page_references() -> None:
+    """The SYF symptom: body is literally just page ranges + separators."""
+    assert _is_toc_shaped("8 - 24 , 80 - 85 , 88 - 97") is True
+    assert _is_toc_shaped("8 - 24") is True
+    assert _is_toc_shaped("103 - 150") is True
+
+
+def test_is_toc_shaped_high_digit_density() -> None:
+    """Page-reference patterns mixed with brief item labels are still TOC."""
+    assert _is_toc_shaped("Item 1A 25 - 50") is True
+
+
+def test_is_toc_shaped_substantive_body_returns_false() -> None:
+    """A real section body is mostly prose, not digits."""
+    assert _is_toc_shaped("We are a global technology company. " * 5) is False
+    assert _is_toc_shaped(
+        "Our business is concentrated in cloud infrastructure. "
+        "Revenue grew 15% to $50 billion."
+    ) is False
+
+
+def test_is_toc_shaped_pointer_text_returns_false() -> None:
+    """Issue #26 pointer-only sections aren't TOC — they're real prose."""
+    assert _is_toc_shaped(
+        "The information required by this Item is included in the Annual "
+        "Report to Stockholders filed as Exhibit 13."
+    ) is False
+    assert _is_toc_shaped("Refer to 'Financial Statements and Supplementary Data' in this report.") is False
+
+
+def test_is_toc_shaped_short_substantive_returns_false() -> None:
+    """A short but substantive body ('Not applicable') isn't TOC."""
+    assert _is_toc_shaped("Not applicable.") is False
+
+
+def test_is_toc_shaped_long_body_never_toc() -> None:
+    """Bodies > 500 chars are always substantive — TOC fragments are bounded."""
+    long_with_digits = "0123456789 " * 100  # > 500 chars, digit-heavy
+    assert _is_toc_shaped(long_with_digits) is False
+
+
+def test_is_toc_shaped_empty() -> None:
+    assert _is_toc_shaped("") is False
+    assert _is_toc_shaped("   \n  \n  ") is False
+
+
+# ---- extract_sections_from_text TOC-aware retry ---------------------------
+
+
+def test_extract_returns_empty_when_only_toc_matches_and_no_part_i_anchor() -> None:
+    """SYF-style pathology with no PART I to retry from → signal failure.
+
+    The caller (extract_sections_for_form) treats an empty result as
+    extraction failure and falls back to generic extraction.
+    """
+    sections = extract_sections_from_text(_SYF_STYLE_TOC_TEXT)
+    assert sections == []
+
+
+def test_extract_smart_retry_finds_body_after_part_i_anchor() -> None:
+    """When the TOC matches but PART I sits before substantive bodies, retry
+    starting from PART I finds the real section headings."""
+    sections = extract_sections_from_text(_SYF_STYLE_WITH_PART_I_AND_BODY)
+
+    labels = [s.label for s in sections]
+    assert "business" in labels
+    assert "risk_factors" in labels
+
+    # Bodies should now be substantive prose, not page references
+    business = next(s for s in sections if s.label == "business")
+    assert "premier consumer financial services" in business.text
+    assert _is_toc_shaped(business.text) is False
+
+
+def test_extract_for_form_falls_back_to_generic_on_toc_failure() -> None:
+    """End-to-end: extract_sections_for_form should fall back to generic
+    when curated extraction returns [] due to TOC-only matches."""
+    # Markdown-style content with a clear heading so generic extraction has
+    # something to find. The curated regex anchored on the TOC entries above.
+    text = _SYF_STYLE_TOC_TEXT + "\n\n## Some heading\n\nSome substantive content."
+    # Convert to HTML so we exercise the html-path of extract_sections_for_form
+    html = f"<html><body><pre>{text}</pre></body></html>"
+    sections = extract_sections_for_form(html, form="10-K", content_type="html")
+    # We should get SOMETHING — either generic-extracted sections or at least
+    # the fallback single-section produced by _split_markdown_top_level.
+    assert sections, "expected fallback to generic extraction when curated finds only TOC"
+
+
+def test_extract_normal_10k_unaffected_by_toc_retry() -> None:
+    """Regression guard: a normal 10-K with real body headings still works.
+
+    SAMPLE_10K_HTML has clean body headings (no separate TOC), so the
+    first-pass curated regex succeeds and the retry path never fires.
+    """
+    sections = extract_sections(SAMPLE_10K_HTML)
+    labels = [s.label for s in sections]
+    assert "business" in labels
+    assert "risk_factors" in labels
+    # Bodies are substantive
+    business = next(s for s in sections if s.label == "business")
+    assert _is_toc_shaped(business.text) is False


### PR DESCRIPTION
Closes #32.

## Summary

The curated section extractor for 10-K/10-Q filings was matching section headers in the **Table of Contents** instead of the actual section bodies on filers like SYF (verified on two recent 10-Ks). All four curated sections ended up with page-range strings like `"8 - 24 , 80 - 85 , 88 - 97"` instead of substantive content. This PR adds TOC-aware smart retry so the extractor recognizes when it captured TOC fragments and retries from after a `PART I` anchor, falling back to generic extraction if that fails too.

## Root cause

The curated regex requires section-name text immediately after the item number (e.g., `r\"item\\s*1\\b(?!a)[\\.\\s\\-:–—]*business\\b\"`). On filers whose body heading uses extra words (\"Item 1. Description of Business\") or split HTML markup (\"<b>Item 1.</b>\" + \"<b>Business</b>\" on separate lines), the regex doesn't match the body — only the TOC entry where the heading is clean. The extracted body is then whatever sits between two adjacent TOC entries: page references.

## Fix — two-pass with TOC-aware smart retry

```python
def extract_sections_from_text(text):
    sections = _curated_pass(text, search_start=0)

    # First-pass success: at least one body is substantive
    if not _all_toc_shaped(sections):
        return sections

    # All TOC-shaped: retry from after the PART I anchor
    anchor = _PART_ONE_ANCHOR_RE.search(text)
    if anchor is not None:
        retry = _curated_pass(text, search_start=anchor.end())
        if retry and not _all_toc_shaped(retry):
            return retry

    # Retry failed: signal failure so caller falls back to generic
    return []
```

**Conservative activation:** the retry only fires when EVERY captured body looks like a TOC fragment. Normal 10-Ks (where first-pass extraction finds substantive bodies) are completely unaffected — verified by the existing SAMPLE_10K_HTML regression test.

## `_is_toc_shaped` heuristic

Four-layered detection, tuned against real SYF observations:

| Signal | Example | Flags? |
|---|---|---|
| Pure separators + digits | `\"8 - 24 , 80 - 85\"` | ✅ TOC |
| One page-range in short body (<100 chars) | `\"and Supplementary Data 103 - 150\"` | ✅ TOC |
| Two+ page-ranges anywhere | `\"25 - 50, 53 - 57\"` | ✅ TOC |
| High digit density (>40%) in body head | terse `\"Pages 56-108\"` style | ✅ TOC |
| Substantive prose | normal body | ❌ |
| Pointer text (issue #26) | `\"...incorporated by reference to Exhibit 13\"` | ❌ |
| Short substantive | `\"Not applicable.\"` | ❌ |
| Long body (>500 chars) | normal section | ❌ (always) |

## Files changed

| File | Change |
|---|---|
| `lib/ai_buffett_zo/secrag/sections.py` | Refactors `extract_sections_from_text` into a `_curated_pass` helper + adds `_is_toc_shaped` / `_all_toc_shaped` / `_PART_ONE_ANCHOR_RE` / `_TOC_BODY_PURE_RE` / `_TOC_PAGE_RANGE_RE` / `_TOC_DIGIT_DENSITY_THRESHOLD`. |
| `tests/test_secrag_sections.py` | 11 new tests covering `_is_toc_shaped` cases + smart retry happy/failure paths + fallback-to-generic + regression on the canonical sample. |

## Test plan

- [x] 11 new tests in `test_secrag_sections.py` cover all four `_is_toc_shaped` signals, smart retry with/without PART I anchor, fallback-to-generic on TOC failure, regression on normal 10-K
- [x] All 648 existing tests pass on this branch
- [x] Ruff clean
- [ ] **Post-merge end-to-end on canonical Zo:**
  1. Re-run `clarion-setup` to pull this fix
  2. Delete SYF's existing tree: `rm /home/workspace/clarion/sec/SYF/0001601712-26-000006.tree.json.gz`
  3. Re-enqueue: `python research.py index SYF --form 10-K`
  4. After indexing completes, inspect the new tree: section bodies should be either substantive prose (if smart retry found body matches) or generic-extracted markdown sections (if fallback fired)
  5. Confirm `clarion-sec-research search` on SYF returns real content, not page references

## Interaction with other in-flight PRs

| PR | Interaction |
|---|---|
| #28 (Phase 0 detection) | None — different code paths. Both can land independently. |
| #29 (Phase 2 recovery via FilingSummary) | SYF-style filings now have a chance to land in the curated path (via retry) or generic path (via fallback). Either way they produce indexable content, which Phase 2 can recover from if Items 7/8 turn out to be pointer-shaped. |
| #33 (issue #31 ARS skip) | None — different code paths. |

## Related

- Issue #32 (this PR closes it)
- Issue #26 (the original incorporated-by-reference problem) — separate but related to the broader \"sections come back wrong\" symptom family
- The canonical Zo flagged this in their issue #26 review ([comment 4498849973](https://github.com/jingerzz/clarion-intelligence-system/issues/26#issuecomment-4498849973)) as a parser-bug class adjacent to the pointer-only sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)