### PR TITLE
Phase 2: recover pointer-only Items 7/8 via FilingSummary.xml (issue #26)

### DIFF
--- a/lib/ai_buffett_zo/indexer/main.py
+++ b/lib/ai_buffett_zo/indexer/main.py
@@ -53,6 +53,7 @@ from ai_buffett_zo.secrag import (
     save_tree,
     should_full_index,
 )
+from ai_buffett_zo.secrag.recovery import recover_pointer_sections
 
 DEFAULT_POLL_INTERVAL = 5.0
 LOG_FILENAME = ".indexer.log"
@@ -138,6 +139,20 @@ def process_one(
         if not sections:
             raise ValueError(
                 f"no sections extracted from {ticker} {form} (content_type={content_type})"
+            )
+
+        # Phase 2 recovery (issue #26): for 10-Ks where Items 7/8 are
+        # incorporated-by-reference, fetch FilingSummary.xml + R-files from
+        # the same accession and replace the pointer body with the
+        # substantive statements. Wrapped in try/except so a network failure
+        # doesn't break indexing — pointer flag stays True, recovered_via
+        # stays None, search layer surfaces the gap.
+        try:
+            sections = recover_pointer_sections(metadata, sections, sec_root)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "Phase 2 recovery failed for %s %s; continuing with pointer text: %s",
+                ticker, metadata.accession, e,
             )
 
         # Decide indexing path: full LLM-summarized tree (10-K, S-1, etc.) vs

--- a/lib/ai_buffett_zo/secrag/loader.py
+++ b/lib/ai_buffett_zo/secrag/loader.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 import json
 import os
 import re
+import urllib.error
 import urllib.request
+import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from datetime import date, timedelta
 
@@ -20,6 +22,11 @@ DEFAULT_USER_AGENT = "Clarion Intelligence System (clarion@example.com)"
 TICKERS_URL = "https://www.sec.gov/files/company_tickers.json"
 SUBMISSIONS_URL = "https://data.sec.gov/submissions/CIK{cik}.json"
 ARCHIVE_URL = "https://www.sec.gov/Archives/edgar/data/{cik_int}/{accession_nodash}/{primary_doc}"
+# FilingSummary.xml is the iXBRL-rendered manifest at the accession root that
+# lists every report (statements, notes, cover pages, etc.). Recovery for
+# pointer-only Items 7/8 (issue #26) reads this to find the R-file containing
+# the actual Consolidated Income Statement / Balance Sheet / Cash Flows.
+FILING_SUMMARY_URL = "https://www.sec.gov/Archives/edgar/data/{cik_int}/{accession_nodash}/FilingSummary.xml"
 
 
 class FilingNotFound(Exception):
@@ -317,6 +324,156 @@ def _find_by_accession(submissions: dict, accession: str) -> dict:
                 "primary_doc": recent.get("primaryDocument", [""])[i],
             }
     raise FilingNotFound(f"accession {accession} not in recent submissions")
+
+
+# --- FilingSummary.xml + R-file recovery (issue #26 Phase 2) ----------------
+#
+# Modern SEC filings (post-iXBRL adoption, ~2012+) ship a `FilingSummary.xml`
+# manifest at the accession root that catalogs every rendered report:
+#
+#   <Report instance="ibm-20251231.htm">
+#     <IsDefault>false</IsDefault>
+#     <MenuCategory>Statements</MenuCategory>
+#     <ShortName>CONSOLIDATED INCOME STATEMENT</ShortName>
+#     <LongName>1003003 - Statement - CONSOLIDATED INCOME STATEMENT</LongName>
+#     <HtmlFileName>R3.htm</HtmlFileName>
+#     <Position>3</Position>
+#   </Report>
+#
+# Each `R{n}.htm` is a single SEC-rendered HTML table — the actual statement.
+# This is the canonical anchor for recovering substantive content when an
+# Item 7 / Item 8 section is just a pointer (e.g. "see the Annual Report" or
+# "Refer to..."). Verified structure on IBM, KO, PG, NVDA — every modern
+# 10-K has it.
+
+
+@dataclass(frozen=True)
+class FilingSummaryReport:
+    """One <Report> entry in a filing's FilingSummary.xml manifest."""
+
+    short_name: str         # e.g. "CONSOLIDATED INCOME STATEMENT"
+    long_name: str          # e.g. "1003003 - Statement - CONSOLIDATED INCOME STATEMENT"
+    html_file_name: str     # e.g. "R3.htm" — relative to the accession dir
+    menu_category: str      # "Statements" | "Notes" | "Cover" | "Tables" | ""
+    position: int           # ordering in the filing
+
+
+@dataclass(frozen=True)
+class FilingSummary:
+    """Parsed FilingSummary.xml for one accession."""
+
+    reports: list[FilingSummaryReport]
+
+    def statements(self) -> list[FilingSummaryReport]:
+        """Reports the manifest marks as financial statements.
+
+        These are the primary recovery targets for pointer-only Items 7/8.
+        Notes (MenuCategory == "Notes") are deliberately excluded here so
+        callers can opt in separately — they bulk up the recovered content
+        considerably (often 30+ reports vs ~7 for statements).
+        """
+        return [r for r in self.reports if r.menu_category == "Statements"]
+
+
+def fetch_filing_summary_raw(
+    metadata: FilingMetadata,
+    *,
+    user_agent: str | None = None,
+) -> str | None:
+    """Fetch the raw FilingSummary.xml bytes for an accession.
+
+    Returns the XML string, or None when the manifest doesn't exist (404)
+    — typical for pre-iXBRL filings (~pre-2012). Other HTTPErrors / URLError
+    propagate up so callers can log them.
+
+    Lives at the same layer as ``_get_text`` so the recovery cache layer
+    can persist raw XML and parse on read — keeps the cache format simple.
+    """
+    ua = user_agent or os.environ.get("SEC_USER_AGENT") or DEFAULT_USER_AGENT
+    url = FILING_SUMMARY_URL.format(
+        cik_int=int(metadata.cik),
+        accession_nodash=metadata.accession.replace("-", ""),
+    )
+    try:
+        return _get_text(url, user_agent=ua)
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return None
+        raise
+
+
+def fetch_filing_summary(
+    metadata: FilingMetadata,
+    *,
+    user_agent: str | None = None,
+) -> FilingSummary | None:
+    """Fetch and parse FilingSummary.xml for an accession.
+
+    Thin wrapper over ``fetch_filing_summary_raw`` + ``_parse_filing_summary``.
+    Use ``fetch_filing_summary_raw`` directly when the caller needs the
+    raw bytes for caching.
+    """
+    raw = fetch_filing_summary_raw(metadata, user_agent=user_agent)
+    if raw is None:
+        return None
+    return _parse_filing_summary(raw)
+
+
+def fetch_r_file(
+    metadata: FilingMetadata,
+    html_file_name: str,
+    *,
+    user_agent: str | None = None,
+) -> str:
+    """Fetch one rendered statement file (e.g. R3.htm) from an accession.
+
+    Returns the raw HTML string. Caller is responsible for extracting text
+    via `secrag.sections.html_to_text` and concatenating multiple R-files.
+    """
+    ua = user_agent or os.environ.get("SEC_USER_AGENT") or DEFAULT_USER_AGENT
+    url = ARCHIVE_URL.format(
+        cik_int=int(metadata.cik),
+        accession_nodash=metadata.accession.replace("-", ""),
+        primary_doc=html_file_name,
+    )
+    return _get_text(url, user_agent=ua)
+
+
+def _parse_filing_summary(xml: str) -> FilingSummary:
+    """Parse FilingSummary.xml into a typed `FilingSummary`.
+
+    SEC's manifest format is stable across filers but resilient to missing
+    optional fields — `MenuCategory` is occasionally absent for utility
+    reports (e.g. cover pages on some legacy filings). We tolerate that.
+    """
+    root = ET.fromstring(xml)
+    reports: list[FilingSummaryReport] = []
+    for report_elem in root.iter("Report"):
+        reports.append(
+            FilingSummaryReport(
+                short_name=_xml_text(report_elem, "ShortName"),
+                long_name=_xml_text(report_elem, "LongName"),
+                html_file_name=_xml_text(report_elem, "HtmlFileName"),
+                menu_category=_xml_text(report_elem, "MenuCategory"),
+                position=_xml_int(report_elem, "Position"),
+            )
+        )
+    return FilingSummary(reports=reports)
+
+
+def _xml_text(elem: ET.Element, tag: str) -> str:
+    sub = elem.find(tag)
+    if sub is None or sub.text is None:
+        return ""
+    return sub.text.strip()
+
+
+def _xml_int(elem: ET.Element, tag: str) -> int:
+    raw = _xml_text(elem, tag)
+    try:
+        return int(raw)
+    except ValueError:
+        return 0
 
 
 # --- HTTP seams (monkeypatched in tests) ------------------------------------

--- a/lib/ai_buffett_zo/secrag/recovery.py
+++ b/lib/ai_buffett_zo/secrag/recovery.py
@@ -1,0 +1,209 @@
+"""Phase 2 recovery: replace pointer-only Items 7/8 with substantive content.
+
+When Phase 0 flags a 10-K section as `is_pointer_only=True` with a recoverable
+target (annual_report_same_doc / unknown), this module fetches the SEC's
+`FilingSummary.xml` manifest at the accession root and the rendered statement
+R-files (`R3.htm`, `R4.htm`, etc.) listed under `MenuCategory="Statements"`.
+The recovered text replaces the section's pointer body. The original pointer
+flag (`is_pointer_only=True`) is preserved for provenance; a new
+`recovered_via="filing_summary_r_files"` field marks the substitution.
+
+Caching: the manifest and each R-file are persisted under the accession's
+storage dir (`{ticker}/{accession}.filing_summary.xml.gz`,
+`{ticker}/{accession}.rfiles/R{n}.htm.gz`). Re-runs hit the cache; only the
+first index of a given filing actually fetches from SEC.
+
+Fallbacks:
+- Pre-iXBRL filings (~pre-2012) won't have FilingSummary.xml. The fetch
+  returns None; sections stay as pointers with `recovered_via=None`. The
+  query layer can still surface "this section is a pointer" via
+  `is_pointer_only`.
+- HTTP errors other than 404 propagate up — the indexer wraps the call in a
+  try/except and logs failures, so a single failed recovery doesn't break
+  the rest of the indexing pipeline.
+
+Public entry point: ``recover_pointer_sections(metadata, sections, sec_root)``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from pathlib import Path
+
+from ai_buffett_zo.secrag.loader import (
+    FilingMetadata,
+    FilingSummary,
+    _parse_filing_summary,
+    fetch_filing_summary_raw,
+    fetch_r_file,
+)
+from ai_buffett_zo.secrag.sections import Section, html_to_text
+from ai_buffett_zo.secrag.storage import (
+    load_filing_summary,
+    load_r_file,
+    save_filing_summary,
+    save_r_file,
+)
+
+logger = logging.getLogger(__name__)
+
+# Labels and pointer targets where Phase 2 recovery is appropriate. Phase 1
+# (Pattern A — companion DEF 14A auto-enqueue) handles `def14a` separately;
+# `parser_bug` targets are extractor artifacts that shouldn't be "recovered."
+RECOVERABLE_LABELS: frozenset[str] = frozenset({"mdna", "financial_statements"})
+RECOVERABLE_TARGETS: frozenset[str] = frozenset({"annual_report_same_doc", "unknown"})
+
+# Marker stored on recovered sections so downstream consumers (eval skill,
+# audit tools) can tell that the substantive text was assembled from R-files
+# rather than the original primary-doc extraction.
+RECOVERED_VIA_FILING_SUMMARY = "filing_summary_r_files"
+
+
+def is_recoverable(section: Section) -> bool:
+    """Is this section a Phase 2 recovery candidate?"""
+    return (
+        section.is_pointer_only
+        and section.label in RECOVERABLE_LABELS
+        and section.pointer_target in RECOVERABLE_TARGETS
+    )
+
+
+def recover_pointer_sections(
+    metadata: FilingMetadata,
+    sections: list[Section],
+    sec_root: Path,
+) -> list[Section]:
+    """Replace pointer-only Items 7/8 with substantive content from R-files.
+
+    Returns a new list of sections — unmodified entries pass through as-is.
+    For each recoverable pointer section, the returned entry has:
+
+    - ``text``: concatenated text of every `MenuCategory="Statements"` R-file
+      in the filing's manifest, with each statement prefixed by its
+      ``ShortName`` header (e.g. ``"# CONSOLIDATED INCOME STATEMENT"``).
+    - ``is_pointer_only``: still True (preserves provenance — section was
+      originally a pointer).
+    - ``recovered_via``: ``"filing_summary_r_files"``.
+
+    On any failure path (no FilingSummary, empty Statements list, fetch
+    error), the section is returned unchanged. Callers should NOT assume
+    recovery succeeded; they can check ``recovered_via is not None``.
+    """
+    if not any(is_recoverable(s) for s in sections):
+        return sections
+
+    summary = _get_or_fetch_summary(metadata, sec_root)
+    if summary is None:
+        logger.info(
+            "Phase 2 recovery skipped: no FilingSummary.xml for %s %s",
+            metadata.ticker, metadata.accession,
+        )
+        return sections
+
+    statements = summary.statements()
+    if not statements:
+        logger.info(
+            "Phase 2 recovery skipped: no Statements reports in FilingSummary for %s %s",
+            metadata.ticker, metadata.accession,
+        )
+        return sections
+
+    recovered_text = _assemble_recovered_text(metadata, statements, sec_root)
+    if not recovered_text:
+        logger.warning(
+            "Phase 2 recovery: all R-file fetches failed for %s %s",
+            metadata.ticker, metadata.accession,
+        )
+        return sections
+
+    out: list[Section] = []
+    for s in sections:
+        if is_recoverable(s):
+            out.append(
+                dataclasses.replace(
+                    s,
+                    text=recovered_text,
+                    recovered_via=RECOVERED_VIA_FILING_SUMMARY,
+                )
+            )
+        else:
+            out.append(s)
+    logger.info(
+        "Phase 2 recovery applied to %s %s: %d statements, %d chars",
+        metadata.ticker, metadata.accession,
+        len(statements), len(recovered_text),
+    )
+    return out
+
+
+def _get_or_fetch_summary(
+    metadata: FilingMetadata,
+    sec_root: Path,
+) -> FilingSummary | None:
+    """Return parsed FilingSummary, hitting the local cache before SEC.
+
+    Cache miss → one HTTP fetch, save raw XML to cache, parse + return.
+    404 → return None (pre-iXBRL filing). Other HTTPErrors propagate up.
+    """
+    cached_xml = load_filing_summary(sec_root, metadata.ticker, metadata.accession)
+    if cached_xml is not None:
+        return _parse_filing_summary(cached_xml)
+
+    raw_xml = fetch_filing_summary_raw(metadata)
+    if raw_xml is None:
+        # Pre-iXBRL filing or genuinely missing manifest. Don't cache the
+        # "not found" — cheap to retry on the next index run in case the
+        # filing gets amended.
+        return None
+
+    save_filing_summary(sec_root, metadata.ticker, metadata.accession, raw_xml)
+    return _parse_filing_summary(raw_xml)
+
+
+def _assemble_recovered_text(
+    metadata: FilingMetadata,
+    statements: list,  # list[FilingSummaryReport]
+    sec_root: Path,
+) -> str:
+    """Fetch + concatenate R-file text for every Statements report.
+
+    Each R-file is fetched once (cache-first). Text is prefixed with a
+    ``# ShortName`` heading so downstream readers can tell where one
+    statement ends and the next begins.
+    """
+    pieces: list[str] = []
+    for report in statements:
+        html = _get_or_fetch_r_file(metadata, report.html_file_name, sec_root)
+        if html is None:
+            logger.warning(
+                "Phase 2 recovery: R-file %s missing for %s %s",
+                report.html_file_name, metadata.ticker, metadata.accession,
+            )
+            continue
+        text = html_to_text(html)
+        if not text:
+            continue
+        pieces.append(f"# {report.short_name}\n\n{text}")
+    return "\n\n".join(pieces)
+
+
+def _get_or_fetch_r_file(
+    metadata: FilingMetadata,
+    name: str,
+    sec_root: Path,
+) -> str | None:
+    """Return cached R-file HTML, fetching + caching on a cold miss."""
+    cached = load_r_file(sec_root, metadata.ticker, metadata.accession, name)
+    if cached is not None:
+        return cached
+    try:
+        html = fetch_r_file(metadata, name)
+    except Exception as e:  # noqa: BLE001 — network errors are heterogeneous
+        logger.warning(
+            "Phase 2 recovery: R-file fetch failed for %s %s %s: %s",
+            metadata.ticker, metadata.accession, name, e,
+        )
+        return None
+    save_r_file(sec_root, metadata.ticker, metadata.accession, name, html)
+    return html

--- a/lib/ai_buffett_zo/secrag/recovery.py
+++ b/lib/ai_buffett_zo/secrag/recovery.py
@@ -49,10 +49,24 @@ from ai_buffett_zo.secrag.storage import (
 logger = logging.getLogger(__name__)
 
 # Labels and pointer targets where Phase 2 recovery is appropriate. Phase 1
-# (Pattern A — companion DEF 14A auto-enqueue) handles `def14a` separately;
-# `parser_bug` targets are extractor artifacts that shouldn't be "recovered."
+# (Pattern A — companion DEF 14A auto-enqueue) handles `def14a` separately.
+#
+# `parser_bug` is included after real-data validation on cis.zo.computer
+# (PR #29 review, 2026-05-22): KO's Item 8 was getting classified as
+# `parser_bug` because the curated regex trimmed the "Refer to" prefix off
+# its pointer text, leaving a body with no pointer-language tokens.
+# Excluding `parser_bug` from recovery meant KO got no fix despite having a
+# valid FilingSummary. True parser bugs (PWR business="and", MSFT TOC
+# fragments) also flow through, but FilingSummary recovery degrades
+# gracefully when no manifest exists or no Statements reports are listed —
+# so attempting recovery on parser_bug is safe and meaningfully improves
+# coverage.
 RECOVERABLE_LABELS: frozenset[str] = frozenset({"mdna", "financial_statements"})
-RECOVERABLE_TARGETS: frozenset[str] = frozenset({"annual_report_same_doc", "unknown"})
+RECOVERABLE_TARGETS: frozenset[str] = frozenset({
+    "annual_report_same_doc",
+    "unknown",
+    "parser_bug",
+})
 
 # Marker stored on recovered sections so downstream consumers (eval skill,
 # audit tools) can tell that the substantive text was assembled from R-files

--- a/lib/ai_buffett_zo/secrag/search.py
+++ b/lib/ai_buffett_zo/secrag/search.py
@@ -82,6 +82,7 @@ class SearchHit:
     citation: str
     is_pointer_only: bool = False
     pointer_target: str | None = None
+    recovered_via: str | None = None
 
 
 def search(
@@ -337,6 +338,7 @@ def _hit_from_entry(
         citation=_citation(meta.ticker, meta.form, meta.filed.isoformat(), path),
         is_pointer_only=section.is_pointer_only,
         pointer_target=section.pointer_target,
+        recovered_via=section.recovered_via,
     )
 
 
@@ -383,6 +385,7 @@ def _score_section(
         citation=_citation(meta.ticker, meta.form, meta.filed.isoformat(), section.label),
         is_pointer_only=section.is_pointer_only,
         pointer_target=section.pointer_target,
+        recovered_via=section.recovered_via,
     )
 
 
@@ -412,6 +415,7 @@ def _score_chunk(
         citation=_citation(meta.ticker, meta.form, meta.filed.isoformat(), path),
         is_pointer_only=section.is_pointer_only,
         pointer_target=section.pointer_target,
+        recovered_via=section.recovered_via,
     )
 
 

--- a/lib/ai_buffett_zo/secrag/search.py
+++ b/lib/ai_buffett_zo/secrag/search.py
@@ -62,6 +62,12 @@ class SearchHit:
     snippet: short excerpt of `text` around the first matched keyword.
     citation: human-readable, e.g. "NVDA 10-K filed 2026-02-21 → risk_factors".
     path: e.g. "risk_factors" or "risk_factors/chunk2"
+
+    is_pointer_only + pointer_target: True when the hit came from a section
+    that incorporates substantive content by reference (Items 10-14 → DEF 14A,
+    Items 7-8 → Annual Report). Callers (e.g. the eval skill) can surface
+    "this section is a pointer; substantive content lives in [target]" instead
+    of treating the snippet as fact.
     """
 
     ticker: str
@@ -74,6 +80,8 @@ class SearchHit:
     snippet: str
     score: float
     citation: str
+    is_pointer_only: bool = False
+    pointer_target: str | None = None
 
 
 def search(
@@ -327,6 +335,8 @@ def _hit_from_entry(
         snippet=snippet,
         score=score,
         citation=_citation(meta.ticker, meta.form, meta.filed.isoformat(), path),
+        is_pointer_only=section.is_pointer_only,
+        pointer_target=section.pointer_target,
     )
 
 
@@ -371,6 +381,8 @@ def _score_section(
         snippet=snippet,
         score=score,
         citation=_citation(meta.ticker, meta.form, meta.filed.isoformat(), section.label),
+        is_pointer_only=section.is_pointer_only,
+        pointer_target=section.pointer_target,
     )
 
 
@@ -398,6 +410,8 @@ def _score_chunk(
         snippet=snippet,
         score=score,
         citation=_citation(meta.ticker, meta.form, meta.filed.isoformat(), path),
+        is_pointer_only=section.is_pointer_only,
+        pointer_target=section.pointer_target,
     )
 
 

--- a/lib/ai_buffett_zo/secrag/sections.py
+++ b/lib/ai_buffett_zo/secrag/sections.py
@@ -120,8 +120,23 @@ POINTER_TARGET_DEF14A_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Pointer-language markers used to distinguish "real but unrecognized pointer"
+# from "parser-extraction bug." Short curated 10-K sections almost always
+# contain at least one of these tokens when they're a genuine pointer
+# (canonical "incorporated by reference", varied "Refer to...", "see our
+# Consolidated...", "is set forth in...", or even bare "Pages 56-108"). Short
+# sections WITHOUT any of these tokens are typically parser bugs — TOC
+# fragments, orphan whitespace, the `ANY_ITEM_HEADER` regex anchoring on a
+# table-of-contents line instead of the body. Phase 2 should skip recovery on
+# those; the underlying extractor regex is tracked separately.
+POINTER_LANGUAGE_RE = re.compile(
+    r"\brefer\b|\bsee\b|\bincorporat(?:ed|ing)\b|\bset\s+forth\b"
+    r"|\binformation\s+required\b|\bpages?\s+\d",
+    re.IGNORECASE,
+)
+
 # Threshold for "section body is too short to be substantive 10-K content."
-# Real Items 7-8 pointers in IBM/KO/NVDA/INTC measure 177-499 chars; real
+# Real Items 7-8 pointers in IBM/KO/NVDA/INTC measure 37-499 chars; real
 # legitimate-content sections in the same dataset start at ~540 chars (MU
 # mdna). 500 is the natural cut-line.
 POINTER_BODY_MAX_CHARS = 500
@@ -134,24 +149,37 @@ def _detect_pointer(body: str) -> tuple[bool, str | None]:
     much to use as a gate ("Refer to...", "see our Consolidated...", "is set
     forth in...", page-only references). Curated 10-K sections are normally
     multi-page; bodies under ``POINTER_BODY_MAX_CHARS`` (500) are almost
-    always either pointers or TOC-capture parser bugs — both worth flagging
-    for downstream recovery.
+    always either pointers or parser-extraction bugs.
 
-    The phrase regexes are used purely for classification: once a section is
-    flagged short, they decide the most likely target document (Annual
-    Report / Exhibit 13 in same doc, separate DEF 14A, or unknown).
+    Classification distinguishes the two so Phase 2 can act differently:
 
-    Returns ``(is_pointer_only, pointer_target)``:
+    - ``"annual_report_same_doc"`` — body mentions Annual Report to
+      Stockholders or Exhibit 13 (Pattern B: companion-document recovery
+      via FilingSummary.xml + R-files).
+    - ``"def14a"`` — body mentions Proxy Statement or Schedule 14A
+      (Pattern A: companion DEF 14A auto-enqueue, handled by Phase 1).
+    - ``"unknown"`` — body has at least one pointer-language marker but
+      doesn't match a specific target document. Phase 2 should still
+      attempt FilingSummary recovery; most "unknown" cases turn out to
+      be same-doc pointers using varied phrasing.
+    - ``"parser_bug"`` — body has NO pointer-language markers at all.
+      These are TOC fragments, orphan whitespace, or other extractor
+      artifacts (e.g. PWR business="and" at 3 chars). Phase 2 should
+      skip recovery; the underlying extractor regex needs separate fix.
 
-    - ``is_pointer_only``: True iff body is shorter than the threshold.
-    - ``pointer_target``: ``"annual_report_same_doc"``, ``"def14a"``,
-      ``"unknown"``, or ``None`` when ``is_pointer_only`` is False.
+    Returns ``(is_pointer_only, pointer_target)``. ``is_pointer_only`` is
+    True iff body is shorter than the threshold; ``pointer_target`` is one
+    of the four strings above or ``None`` when not a pointer.
 
     Only call this on curated 10-K/10-Q sections. Generic extraction (DEF
     14A, Form 4, etc.) has legitimate short sections and shouldn't be flagged.
     """
     if len(body) >= POINTER_BODY_MAX_CHARS:
         return False, None
+    # Short body without any pointer-language markers → parser bug. Don't
+    # let Phase 2 try to "recover" content that was never there.
+    if not POINTER_LANGUAGE_RE.search(body):
+        return True, "parser_bug"
     if POINTER_TARGET_ANNUAL_REPORT_RE.search(body):
         return True, "annual_report_same_doc"
     if POINTER_TARGET_DEF14A_RE.search(body):

--- a/lib/ai_buffett_zo/secrag/sections.py
+++ b/lib/ai_buffett_zo/secrag/sections.py
@@ -40,6 +40,11 @@ class Section:
     - A canonical 10-K name: "business" | "risk_factors" | "mdna" | "financial_statements"
     - A slug derived from the heading title (for generic extraction):
       "prospectus-summary" | "form-4" | "executive-compensation" | etc.
+
+    Pointer-only sections (those that incorporate substantive content by
+    reference instead of containing it inline) are flagged so downstream
+    consumers can either follow the pointer or surface the gap to the user.
+    See `_detect_pointer` for the heuristic.
     """
 
     label: str
@@ -47,6 +52,8 @@ class Section:
     text: str           # body text under this heading
     char_start: int     # offset in the normalized doc
     char_end: int
+    is_pointer_only: bool = False         # True when body is just an "incorporated by reference" pointer
+    pointer_target: str | None = None     # "def14a" | "annual_report_same_doc" | "unknown" | None
 
 
 # ---- Curated 10-K / 10-Q paths --------------------------------------------
@@ -77,6 +84,79 @@ ANY_ITEM_HEADER = re.compile(
     r"\bitem\s*\d+[a-z]?\b[\.\s\-:–—]",
     re.IGNORECASE,
 )
+
+# ---- Pointer-section detection --------------------------------------------
+#
+# Some 10-K sections (especially Items 7-8 and 10-14) are short pointers that
+# direct the reader to substantive content elsewhere — sometimes in a
+# companion DEF 14A proxy filing, sometimes later in the same primary 10-K doc
+# (as "Exhibit 13" or "Annual Report"), sometimes just a page reference like
+# "Pages 56-108".
+#
+# **Detection is length-only for curated 10-K/10-Q sections** (Items 1, 1A, 7,
+# 8). Real-data sweep against 30 indexed 10-Ks (2026-05-20) showed pointer
+# language is wildly varied — only 3 of 11 short pointers used the
+# "incorporated by reference" phrasing. The others said "Refer to...", "see
+# our Consolidated Financial Statements", "is set forth in...", or just page
+# numbers. Length is the only reliable signal because curated 10-K sections
+# are normally multi-page; a short body is almost always a pointer or a
+# TOC-capture parser bug (both useful to flag for downstream recovery).
+#
+# Phrase patterns below are used purely for **classification** — once a
+# section is flagged short, the patterns decide what kind of pointer it
+# probably is so Phase 1/2 can pick the right recovery strategy. Phrase
+# matches don't gate detection.
+
+# Distinguishes which document the pointer points to. Annual-Report references
+# are checked first because Pattern B (Items 7/8 → same-doc continuation) is
+# higher severity than Pattern A (Items 10-14 → companion DEF 14A); when both
+# match, the more-severe target wins.
+POINTER_TARGET_ANNUAL_REPORT_RE = re.compile(
+    r"annual\s+report\s+to\s+(?:stockholders|shareholders)|exhibit\s+13\b",
+    re.IGNORECASE,
+)
+POINTER_TARGET_DEF14A_RE = re.compile(
+    r"proxy\s+statement|schedule\s+14a|def\s*14a",
+    re.IGNORECASE,
+)
+
+# Threshold for "section body is too short to be substantive 10-K content."
+# Real Items 7-8 pointers in IBM/KO/NVDA/INTC measure 177-499 chars; real
+# legitimate-content sections in the same dataset start at ~540 chars (MU
+# mdna). 500 is the natural cut-line.
+POINTER_BODY_MAX_CHARS = 500
+
+
+def _detect_pointer(body: str) -> tuple[bool, str | None]:
+    """Classify a curated 10-K section body as pointer-only or substantive.
+
+    **Detection is length-only.** Pointer phrasing in real 10-Ks varies too
+    much to use as a gate ("Refer to...", "see our Consolidated...", "is set
+    forth in...", page-only references). Curated 10-K sections are normally
+    multi-page; bodies under ``POINTER_BODY_MAX_CHARS`` (500) are almost
+    always either pointers or TOC-capture parser bugs — both worth flagging
+    for downstream recovery.
+
+    The phrase regexes are used purely for classification: once a section is
+    flagged short, they decide the most likely target document (Annual
+    Report / Exhibit 13 in same doc, separate DEF 14A, or unknown).
+
+    Returns ``(is_pointer_only, pointer_target)``:
+
+    - ``is_pointer_only``: True iff body is shorter than the threshold.
+    - ``pointer_target``: ``"annual_report_same_doc"``, ``"def14a"``,
+      ``"unknown"``, or ``None`` when ``is_pointer_only`` is False.
+
+    Only call this on curated 10-K/10-Q sections. Generic extraction (DEF
+    14A, Form 4, etc.) has legitimate short sections and shouldn't be flagged.
+    """
+    if len(body) >= POINTER_BODY_MAX_CHARS:
+        return False, None
+    if POINTER_TARGET_ANNUAL_REPORT_RE.search(body):
+        return True, "annual_report_same_doc"
+    if POINTER_TARGET_DEF14A_RE.search(body):
+        return True, "def14a"
+    return True, "unknown"
 
 # Form types that use the curated 10-K extraction path. All other forms use
 # generic extraction.
@@ -171,6 +251,7 @@ def extract_sections_from_text(text: str) -> list[Section]:
             end = _find_section_end(text, after=m.end())
         body = text[m.end():end].strip()
         title_line = text[m.start():m.end()].strip()
+        is_pointer, target = _detect_pointer(body)
         sections.append(
             Section(
                 label=label,
@@ -178,6 +259,8 @@ def extract_sections_from_text(text: str) -> list[Section]:
                 text=body,
                 char_start=start,
                 char_end=end,
+                is_pointer_only=is_pointer,
+                pointer_target=target,
             )
         )
     return sections
@@ -217,7 +300,10 @@ def _split_markdown_top_level(markdown: str) -> list[Section]:
     """Split markdown on its top-level (shallowest) heading level."""
     matches = list(_HEADING_RE.finditer(markdown))
     if not matches:
-        # No headings — return one section with the whole text
+        # No headings — return one section with the whole text. Pointer
+        # detection skipped on the generic path; DEF 14A / Form 4 / 8-K
+        # have legitimate short sections that the length-only detector
+        # would over-flag.
         return [
             Section(
                 label="filing-content",
@@ -240,6 +326,9 @@ def _split_markdown_top_level(markdown: str) -> list[Section]:
         body = markdown[start:end].strip()
         if not title and not body:
             continue
+        # Pointer detection deliberately skipped on the generic path — see the
+        # docstring on `_detect_pointer`. Curated 10-K/10-Q extraction (above)
+        # is the only call site.
         sections.append(
             Section(
                 label=_slugify(title),

--- a/lib/ai_buffett_zo/secrag/sections.py
+++ b/lib/ai_buffett_zo/secrag/sections.py
@@ -53,7 +53,8 @@ class Section:
     char_start: int     # offset in the normalized doc
     char_end: int
     is_pointer_only: bool = False         # True when body is just an "incorporated by reference" pointer
-    pointer_target: str | None = None     # "def14a" | "annual_report_same_doc" | "unknown" | None
+    pointer_target: str | None = None     # "def14a" | "annual_report_same_doc" | "parser_bug" | "unknown" | None
+    recovered_via: str | None = None      # "filing_summary_r_files" when Phase 2 replaced the pointer with substantive content; None otherwise
 
 
 # ---- Curated 10-K / 10-Q paths --------------------------------------------

--- a/lib/ai_buffett_zo/secrag/storage.py
+++ b/lib/ai_buffett_zo/secrag/storage.py
@@ -89,6 +89,53 @@ def is_indexed(root: Path, ticker: str, accession: str) -> bool:
     return _tree_path(root, ticker, accession).exists()
 
 
+# --- FilingSummary.xml + R-file cache (issue #26 Phase 2) -------------------
+#
+# The recovery flow fetches the manifest + N rendered statement files per
+# pointer-positive filing. Cache them under the accession's storage dir so
+# re-indexing is free and the canonical Zo doesn't hammer SEC's rate limit.
+
+
+def save_filing_summary(root: Path, ticker: str, accession: str, xml: str) -> Path:
+    """Persist the manifest XML for an accession. Gzipped on disk."""
+    path = _filing_summary_path(root, ticker, accession)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(gzip.compress(xml.encode("utf-8")))
+    return path
+
+
+def load_filing_summary(root: Path, ticker: str, accession: str) -> str | None:
+    """Return the cached manifest XML, or None if not yet fetched."""
+    path = _filing_summary_path(root, ticker, accession)
+    if not path.exists():
+        return None
+    return gzip.decompress(path.read_bytes()).decode("utf-8")
+
+
+def save_r_file(
+    root: Path, ticker: str, accession: str, name: str, html: str
+) -> Path:
+    """Persist one rendered statement file (e.g. R3.htm) for an accession.
+
+    `name` is the original SEC filename (no path manipulation — we trust
+    the manifest). Files land under `{ticker}/{accession}.rfiles/`.
+    """
+    path = _r_file_path(root, ticker, accession, name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(gzip.compress(html.encode("utf-8")))
+    return path
+
+
+def load_r_file(
+    root: Path, ticker: str, accession: str, name: str
+) -> str | None:
+    """Return cached R-file HTML, or None if not yet fetched."""
+    path = _r_file_path(root, ticker, accession, name)
+    if not path.exists():
+        return None
+    return gzip.decompress(path.read_bytes()).decode("utf-8")
+
+
 # --- path helpers -----------------------------------------------------------
 
 
@@ -106,6 +153,14 @@ def _tree_path(root: Path, ticker: str, accession: str) -> Path:
 
 def _meta_path(root: Path, ticker: str, accession: str) -> Path:
     return _ticker_dir(root, ticker) / f"{accession}.meta.json"
+
+
+def _filing_summary_path(root: Path, ticker: str, accession: str) -> Path:
+    return _ticker_dir(root, ticker) / f"{accession}.filing_summary.xml.gz"
+
+
+def _r_file_path(root: Path, ticker: str, accession: str, name: str) -> Path:
+    return _ticker_dir(root, ticker) / f"{accession}.rfiles" / f"{name}.gz"
 
 
 def _iter_meta_files(base: Path) -> Iterator[Path]:
@@ -143,6 +198,7 @@ def _section_to_dict(s: SectionNode) -> dict[str, Any]:
         "chunks": [asdict(c) for c in s.chunks],
         "is_pointer_only": s.is_pointer_only,
         "pointer_target": s.pointer_target,
+        "recovered_via": s.recovered_via,
     }
 
 
@@ -178,6 +234,7 @@ def _section_from_dict(d: dict[str, Any]) -> SectionNode:
         # to "substantive" so legacy data continues to behave as before.
         is_pointer_only=d.get("is_pointer_only", False),
         pointer_target=d.get("pointer_target"),
+        recovered_via=d.get("recovered_via"),
     )
 
 

--- a/lib/ai_buffett_zo/secrag/storage.py
+++ b/lib/ai_buffett_zo/secrag/storage.py
@@ -141,6 +141,8 @@ def _section_to_dict(s: SectionNode) -> dict[str, Any]:
         "summary": s.summary,
         "summary_data": s.summary_data,
         "chunks": [asdict(c) for c in s.chunks],
+        "is_pointer_only": s.is_pointer_only,
+        "pointer_target": s.pointer_target,
     }
 
 
@@ -172,6 +174,10 @@ def _section_from_dict(d: dict[str, Any]) -> SectionNode:
         summary=d["summary"],
         summary_data=d.get("summary_data", {}),
         chunks=[_chunk_from_dict(c) for c in d.get("chunks", [])],
+        # Older indexed trees (pre-PR #26 fix) don't have these fields — default
+        # to "substantive" so legacy data continues to behave as before.
+        is_pointer_only=d.get("is_pointer_only", False),
+        pointer_target=d.get("pointer_target"),
     )
 
 

--- a/lib/ai_buffett_zo/secrag/tree.py
+++ b/lib/ai_buffett_zo/secrag/tree.py
@@ -43,7 +43,13 @@ class ChunkNode:
 
 @dataclass
 class SectionNode:
-    """One curated section. `chunks` is empty when section fit under the budget."""
+    """One curated section. `chunks` is empty when section fit under the budget.
+
+    `is_pointer_only` + `pointer_target` carry forward from the source
+    `Section` so downstream consumers (search results, follow-up fixes) can
+    tell whether the section's text is substantive or a pointer to content
+    living elsewhere.
+    """
 
     label: str
     title: str
@@ -51,6 +57,8 @@ class SectionNode:
     summary: str
     summary_data: dict[str, Any]
     chunks: list[ChunkNode] = field(default_factory=list)
+    is_pointer_only: bool = False
+    pointer_target: str | None = None
 
 
 @dataclass(frozen=True)
@@ -86,6 +94,8 @@ def build_raw_tree(metadata: FilingMetadata, sections: list[Section]) -> FilingT
             summary="",
             summary_data={},
             chunks=[],
+            is_pointer_only=s.is_pointer_only,
+            pointer_target=s.pointer_target,
         )
         for s in sections
     ]
@@ -159,6 +169,8 @@ class TreeBuilder:
                 summary=data.get("one_sentence_summary", ""),
                 summary_data=data,
                 chunks=[],
+                is_pointer_only=section.is_pointer_only,
+                pointer_target=section.pointer_target,
             )
 
         chunks_text = _chunk_text(section.text, target_tokens=self.max_chunk_tokens)
@@ -182,6 +194,8 @@ class TreeBuilder:
             summary=synth_data.get("one_sentence_summary", ""),
             summary_data=synth_data,
             chunks=chunk_nodes,
+            is_pointer_only=section.is_pointer_only,
+            pointer_target=section.pointer_target,
         )
 
     def _summarize_text(

--- a/lib/ai_buffett_zo/secrag/tree.py
+++ b/lib/ai_buffett_zo/secrag/tree.py
@@ -59,6 +59,7 @@ class SectionNode:
     chunks: list[ChunkNode] = field(default_factory=list)
     is_pointer_only: bool = False
     pointer_target: str | None = None
+    recovered_via: str | None = None
 
 
 @dataclass(frozen=True)
@@ -96,6 +97,7 @@ def build_raw_tree(metadata: FilingMetadata, sections: list[Section]) -> FilingT
             chunks=[],
             is_pointer_only=s.is_pointer_only,
             pointer_target=s.pointer_target,
+            recovered_via=s.recovered_via,
         )
         for s in sections
     ]
@@ -171,6 +173,7 @@ class TreeBuilder:
                 chunks=[],
                 is_pointer_only=section.is_pointer_only,
                 pointer_target=section.pointer_target,
+                recovered_via=section.recovered_via,
             )
 
         chunks_text = _chunk_text(section.text, target_tokens=self.max_chunk_tokens)
@@ -196,6 +199,7 @@ class TreeBuilder:
             chunks=chunk_nodes,
             is_pointer_only=section.is_pointer_only,
             pointer_target=section.pointer_target,
+            recovered_via=section.recovered_via,
         )
 
     def _summarize_text(

--- a/tests/test_secrag_recovery.py
+++ b/tests/test_secrag_recovery.py
@@ -1,0 +1,401 @@
+"""Tests for ai_buffett_zo.secrag.recovery — Phase 2 pointer recovery.
+
+HTTP is monkeypatched at loader.py's `_get_text` seam. Storage cache uses
+tmp_path fixtures so tests don't touch real ~/clarion data.
+"""
+
+from __future__ import annotations
+
+import urllib.error
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from ai_buffett_zo.secrag import loader
+from ai_buffett_zo.secrag.loader import FilingMetadata
+from ai_buffett_zo.secrag.recovery import (
+    RECOVERED_VIA_FILING_SUMMARY,
+    is_recoverable,
+    recover_pointer_sections,
+)
+from ai_buffett_zo.secrag.sections import Section
+from ai_buffett_zo.secrag.storage import (
+    load_filing_summary,
+    load_r_file,
+)
+
+
+# ---- Fixtures ---------------------------------------------------------------
+
+
+def _metadata(ticker: str = "IBM", accession: str = "0000051143-26-000010") -> FilingMetadata:
+    return FilingMetadata(
+        cik="0000051143",
+        ticker=ticker,
+        company="International Business Machines Corp",
+        form="10-K",
+        filed=date(2026, 2, 24),
+        period=date(2025, 12, 31),
+        accession=accession,
+        primary_doc="ibm-20251231.htm",
+        primary_doc_url="https://www.sec.gov/Archives/edgar/data/51143/000005114326000010/ibm-20251231.htm",
+    )
+
+
+# Minimal but realistic FilingSummary.xml structure. Matches the shape on real
+# IBM/KO/PG/NVDA filings — multiple <Report> entries, MenuCategory varies.
+_IBM_FILING_SUMMARY_XML = """<?xml version="1.0" encoding="utf-8"?>
+<FilingSummary>
+  <Version>2.x</Version>
+  <ProcessingTime/>
+  <ReportFormat>Xml</ReportFormat>
+  <MyReports>
+    <Report instance="ibm-20251231.htm">
+      <IsDefault>true</IsDefault>
+      <HasEmbeddedReports>false</HasEmbeddedReports>
+      <HtmlFileName>R1.htm</HtmlFileName>
+      <LongName>0000001 - Document - Cover Page</LongName>
+      <ReportType>Sheet</ReportType>
+      <Role>http://example.com/role/CoverPage</Role>
+      <ShortName>Cover Page</ShortName>
+      <MenuCategory>Cover</MenuCategory>
+      <Position>1</Position>
+    </Report>
+    <Report instance="ibm-20251231.htm">
+      <IsDefault>false</IsDefault>
+      <HtmlFileName>R3.htm</HtmlFileName>
+      <LongName>1003003 - Statement - CONSOLIDATED INCOME STATEMENT</LongName>
+      <ShortName>CONSOLIDATED INCOME STATEMENT</ShortName>
+      <MenuCategory>Statements</MenuCategory>
+      <Position>3</Position>
+    </Report>
+    <Report instance="ibm-20251231.htm">
+      <IsDefault>false</IsDefault>
+      <HtmlFileName>R4.htm</HtmlFileName>
+      <LongName>1003004 - Statement - CONSOLIDATED BALANCE SHEET</LongName>
+      <ShortName>CONSOLIDATED BALANCE SHEET</ShortName>
+      <MenuCategory>Statements</MenuCategory>
+      <Position>4</Position>
+    </Report>
+    <Report instance="ibm-20251231.htm">
+      <IsDefault>false</IsDefault>
+      <HtmlFileName>R5.htm</HtmlFileName>
+      <LongName>1003005 - Statement - CONSOLIDATED STATEMENT OF CASH FLOWS</LongName>
+      <ShortName>CONSOLIDATED STATEMENT OF CASH FLOWS</ShortName>
+      <MenuCategory>Statements</MenuCategory>
+      <Position>5</Position>
+    </Report>
+    <Report instance="ibm-20251231.htm">
+      <IsDefault>false</IsDefault>
+      <HtmlFileName>R20.htm</HtmlFileName>
+      <LongName>2001020 - Disclosure - Significant Accounting Policies</LongName>
+      <ShortName>Significant Accounting Policies (Notes)</ShortName>
+      <MenuCategory>Notes</MenuCategory>
+      <Position>20</Position>
+    </Report>
+  </MyReports>
+  <InputFiles/>
+  <SupplementalFiles/>
+  <BaseTaxonomies/>
+  <HasPresentationLinkbase>true</HasPresentationLinkbase>
+  <HasCalculationLinkbase>true</HasCalculationLinkbase>
+</FilingSummary>
+"""
+
+# Canned R-file HTML — each statement is one mock SEC-rendered table.
+_R_FILE_CONTENT = {
+    "R1.htm": "<html><body><h1>Cover Page</h1><p>IBM 2025 10-K cover</p></body></html>",
+    "R3.htm": (
+        "<html><body><h1>Consolidated Income Statement</h1>"
+        "<table><tr><td>Total revenue</td><td>$62,753</td></tr>"
+        "<tr><td>Net income</td><td>$7,500</td></tr></table></body></html>"
+    ),
+    "R4.htm": (
+        "<html><body><h1>Consolidated Balance Sheet</h1>"
+        "<table><tr><td>Total assets</td><td>$130,000</td></tr>"
+        "<tr><td>Total liabilities</td><td>$110,000</td></tr></table></body></html>"
+    ),
+    "R5.htm": (
+        "<html><body><h1>Consolidated Statement of Cash Flows</h1>"
+        "<table><tr><td>Operating cash flow</td><td>$13,500</td></tr></table></body></html>"
+    ),
+    "R20.htm": "<html><body><h1>Significant Accounting Policies</h1><p>...</p></body></html>",
+}
+
+
+def _patch_recovery_http(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    summary_xml: str | None = _IBM_FILING_SUMMARY_XML,
+    r_files: dict[str, str] | None = None,
+    summary_status: int = 200,
+    r_file_status: dict[str, int] | None = None,
+) -> dict[str, list[str]]:
+    """Install a fake `_get_text` keyed by URL.
+
+    Returns a dict capturing every URL fetched, so tests can assert
+    cache-hit vs cache-miss behavior.
+    """
+    if r_files is None:
+        r_files = _R_FILE_CONTENT
+    if r_file_status is None:
+        r_file_status = {}
+    captured: dict[str, list[str]] = {"urls": []}
+
+    def fake_get_text(url: str, *, user_agent: str, timeout: int = 60) -> str:
+        captured["urls"].append(url)
+        if "FilingSummary.xml" in url:
+            if summary_status == 404:
+                raise urllib.error.HTTPError(url, 404, "Not Found", {}, None)  # type: ignore[arg-type]
+            if summary_xml is None:
+                raise AssertionError("test asked for FilingSummary but xml is None")
+            return summary_xml
+        # R-file path: figure out which one from the URL
+        for name, content in r_files.items():
+            if url.endswith(name):
+                if r_file_status.get(name, 200) == 404:
+                    raise urllib.error.HTTPError(url, 404, "Not Found", {}, None)  # type: ignore[arg-type]
+                if r_file_status.get(name, 200) >= 500:
+                    raise urllib.error.HTTPError(url, 500, "Server Error", {}, None)  # type: ignore[arg-type]
+                return content
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(loader, "_get_text", fake_get_text)
+    return captured
+
+
+def _pointer_section(label: str = "financial_statements", target: str = "annual_report_same_doc") -> Section:
+    """A Section the way Phase 0 produces it for IBM-style pointer body."""
+    return Section(
+        label=label,
+        title="Item 8. Financial Statements",
+        text="The information required by this Item is included in the Annual Report to Stockholders filed as Exhibit 13.",
+        char_start=10000,
+        char_end=10120,
+        is_pointer_only=True,
+        pointer_target=target,
+    )
+
+
+def _substantive_section() -> Section:
+    """A non-pointer section that should never be touched by Phase 2."""
+    return Section(
+        label="business",
+        title="Item 1. Business",
+        text="IBM is a global technology company. " * 100,
+        char_start=0,
+        char_end=4000,
+    )
+
+
+# ---- is_recoverable --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("label", "is_pointer", "target", "expected"),
+    [
+        ("financial_statements", True, "annual_report_same_doc", True),
+        ("mdna", True, "annual_report_same_doc", True),
+        ("financial_statements", True, "unknown", True),
+        ("mdna", True, "unknown", True),
+        # def14a target is Phase 1's job, not Phase 2's
+        ("financial_statements", True, "def14a", False),
+        # parser_bug should be skipped — not a real pointer
+        ("financial_statements", True, "parser_bug", False),
+        # substantive section
+        ("financial_statements", False, None, False),
+        # other labels don't qualify even if pointer
+        ("business", True, "annual_report_same_doc", False),
+        ("risk_factors", True, "annual_report_same_doc", False),
+    ],
+)
+def test_is_recoverable(label, is_pointer, target, expected) -> None:
+    s = Section(
+        label=label,
+        title="T",
+        text="",
+        char_start=0,
+        char_end=10,
+        is_pointer_only=is_pointer,
+        pointer_target=target,
+    )
+    assert is_recoverable(s) is expected
+
+
+# ---- recover_pointer_sections — happy path ---------------------------------
+
+
+def test_recover_replaces_pointer_with_r_file_content(monkeypatch, tmp_path: Path) -> None:
+    """Happy path: pointer Item 8 → text becomes concatenated R-file content."""
+    _patch_recovery_http(monkeypatch)
+    sections = [_substantive_section(), _pointer_section()]
+
+    out = recover_pointer_sections(_metadata(), sections, tmp_path)
+
+    # Substantive section unchanged
+    assert out[0].text == sections[0].text
+    assert out[0].recovered_via is None
+    assert out[0].is_pointer_only is False
+
+    # Pointer section recovered
+    recovered = out[1]
+    assert recovered.recovered_via == RECOVERED_VIA_FILING_SUMMARY
+    assert recovered.is_pointer_only is True  # provenance preserved
+    assert "Consolidated Income Statement" in recovered.text
+    assert "Total revenue" in recovered.text
+    assert "Consolidated Balance Sheet" in recovered.text
+    assert "Total assets" in recovered.text
+    assert "Consolidated Statement of Cash Flows" in recovered.text
+    # Notes (Significant Accounting Policies) should NOT be in the default
+    # recovered text — only Statements
+    assert "Significant Accounting Policies" not in recovered.text
+    # Cover page should also be excluded
+    assert "IBM 2025 10-K cover" not in recovered.text
+
+
+def test_recover_handles_target_unknown(monkeypatch, tmp_path: Path) -> None:
+    """`unknown` target (the KO/NVDA/INTC majority case) also triggers recovery."""
+    _patch_recovery_http(monkeypatch)
+    sections = [_pointer_section(target="unknown")]
+    out = recover_pointer_sections(_metadata(), sections, tmp_path)
+    assert out[0].recovered_via == RECOVERED_VIA_FILING_SUMMARY
+
+
+def test_recover_skips_def14a_target(monkeypatch, tmp_path: Path) -> None:
+    """def14a is Phase 1's territory; Phase 2 leaves it alone."""
+    captured = _patch_recovery_http(monkeypatch)
+    sections = [_pointer_section(target="def14a")]
+    out = recover_pointer_sections(_metadata(), sections, tmp_path)
+    assert out[0].recovered_via is None
+    assert out[0].text == sections[0].text
+    # No HTTP should have happened — early-exit because no recoverable section
+    assert captured["urls"] == []
+
+
+def test_recover_skips_parser_bug_target(monkeypatch, tmp_path: Path) -> None:
+    """parser_bug sections are extractor artifacts; no recovery attempted."""
+    captured = _patch_recovery_http(monkeypatch)
+    sections = [_pointer_section(target="parser_bug")]
+    out = recover_pointer_sections(_metadata(), sections, tmp_path)
+    assert out[0].recovered_via is None
+    assert captured["urls"] == []
+
+
+def test_recover_no_op_when_no_recoverable_sections(monkeypatch, tmp_path: Path) -> None:
+    """No recoverable sections → no HTTP, return list unchanged."""
+    captured = _patch_recovery_http(monkeypatch)
+    sections = [_substantive_section()]
+    out = recover_pointer_sections(_metadata(), sections, tmp_path)
+    assert out == sections
+    assert captured["urls"] == []
+
+
+# ---- Caching ---------------------------------------------------------------
+
+
+def test_recover_caches_filing_summary_and_r_files(monkeypatch, tmp_path: Path) -> None:
+    """Cache cold → fetch + persist. Cache warm → no further HTTP."""
+    captured = _patch_recovery_http(monkeypatch)
+    sections = [_pointer_section()]
+    md = _metadata()
+
+    # First run: cold cache
+    recover_pointer_sections(md, sections, tmp_path)
+    first_run_urls = list(captured["urls"])
+    assert any("FilingSummary.xml" in u for u in first_run_urls)
+    assert any(u.endswith("R3.htm") for u in first_run_urls)
+    # Cache files written
+    assert load_filing_summary(tmp_path, md.ticker, md.accession) is not None
+    assert load_r_file(tmp_path, md.ticker, md.accession, "R3.htm") is not None
+    assert load_r_file(tmp_path, md.ticker, md.accession, "R4.htm") is not None
+
+    # Second run: cache warm
+    captured["urls"].clear()
+    recover_pointer_sections(md, sections, tmp_path)
+    assert captured["urls"] == []  # zero HTTP on warm cache
+
+
+# ---- Graceful degradation -------------------------------------------------
+
+
+def test_recover_returns_unchanged_when_no_filing_summary(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Pre-iXBRL filing (404 on FilingSummary) — section stays as pointer."""
+    _patch_recovery_http(monkeypatch, summary_status=404)
+    sections = [_pointer_section()]
+    out = recover_pointer_sections(_metadata(), sections, tmp_path)
+    assert out[0].recovered_via is None
+    assert out[0].is_pointer_only is True
+    assert out[0].text == sections[0].text
+
+
+def test_recover_continues_when_one_r_file_fails(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """One R-file 500s → recovery still succeeds with the others."""
+    _patch_recovery_http(
+        monkeypatch,
+        r_file_status={"R4.htm": 500},  # Balance Sheet HTTP-500s
+    )
+    sections = [_pointer_section()]
+    out = recover_pointer_sections(_metadata(), sections, tmp_path)
+    # Still recovered with the surviving statements
+    assert out[0].recovered_via == RECOVERED_VIA_FILING_SUMMARY
+    assert "Total revenue" in out[0].text         # R3 succeeded
+    assert "Total assets" not in out[0].text      # R4 failed
+    assert "Operating cash flow" in out[0].text   # R5 succeeded
+
+
+def test_recover_returns_unchanged_when_no_statements_in_manifest(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Manifest exists but has no `MenuCategory="Statements"` reports."""
+    cover_only_xml = """<?xml version="1.0" encoding="utf-8"?>
+<FilingSummary>
+  <MyReports>
+    <Report instance="x.htm">
+      <HtmlFileName>R1.htm</HtmlFileName>
+      <ShortName>Cover Page</ShortName>
+      <LongName>Cover Page</LongName>
+      <MenuCategory>Cover</MenuCategory>
+      <Position>1</Position>
+    </Report>
+  </MyReports>
+</FilingSummary>
+"""
+    _patch_recovery_http(monkeypatch, summary_xml=cover_only_xml)
+    sections = [_pointer_section()]
+    out = recover_pointer_sections(_metadata(), sections, tmp_path)
+    assert out[0].recovered_via is None
+
+
+# ---- FilingSummary parser unit tests --------------------------------------
+
+
+def test_parse_filing_summary_extracts_all_reports() -> None:
+    summary = loader._parse_filing_summary(_IBM_FILING_SUMMARY_XML)
+    assert len(summary.reports) == 5
+    short_names = [r.short_name for r in summary.reports]
+    assert "CONSOLIDATED INCOME STATEMENT" in short_names
+    assert "CONSOLIDATED BALANCE SHEET" in short_names
+
+
+def test_filing_summary_statements_filters_to_menu_category() -> None:
+    summary = loader._parse_filing_summary(_IBM_FILING_SUMMARY_XML)
+    statements = summary.statements()
+    assert len(statements) == 3
+    assert all(r.menu_category == "Statements" for r in statements)
+
+
+def test_parse_filing_summary_tolerates_missing_optional_fields() -> None:
+    """A <Report> without MenuCategory shouldn't crash the parser."""
+    xml = """<?xml version="1.0"?>
+<FilingSummary><MyReports>
+  <Report><ShortName>X</ShortName><HtmlFileName>R1.htm</HtmlFileName></Report>
+</MyReports></FilingSummary>
+"""
+    summary = loader._parse_filing_summary(xml)
+    assert summary.reports[0].menu_category == ""
+    assert summary.reports[0].position == 0

--- a/tests/test_secrag_recovery.py
+++ b/tests/test_secrag_recovery.py
@@ -201,8 +201,11 @@ def _substantive_section() -> Section:
         ("mdna", True, "unknown", True),
         # def14a target is Phase 1's job, not Phase 2's
         ("financial_statements", True, "def14a", False),
-        # parser_bug should be skipped — not a real pointer
-        ("financial_statements", True, "parser_bug", False),
+        # parser_bug is recoverable — see RECOVERABLE_TARGETS comment in
+        # recovery.py for why (KO classified as parser_bug after Phase 0 trimmed
+        # its "Refer to" prefix; FilingSummary recovery handles it gracefully)
+        ("financial_statements", True, "parser_bug", True),
+        ("mdna", True, "parser_bug", True),
         # substantive section
         ("financial_statements", False, None, False),
         # other labels don't qualify even if pointer
@@ -273,13 +276,36 @@ def test_recover_skips_def14a_target(monkeypatch, tmp_path: Path) -> None:
     assert captured["urls"] == []
 
 
-def test_recover_skips_parser_bug_target(monkeypatch, tmp_path: Path) -> None:
-    """parser_bug sections are extractor artifacts; no recovery attempted."""
-    captured = _patch_recovery_http(monkeypatch)
+def test_recover_attempts_recovery_on_parser_bug_target(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """parser_bug sections get recovery attempt — KO-style cases (Phase 0
+    trimmed the pointer prefix) succeed when FilingSummary exists.
+
+    Per canonical Zo's PR #29 real-data review: KO's Item 8 was getting
+    classified as parser_bug because the curated regex stripped its
+    "Refer to" prefix, leaving a body with no pointer-language tokens.
+    KO has a valid FilingSummary; attempting recovery is the right move.
+    """
+    _patch_recovery_http(monkeypatch)
+    sections = [_pointer_section(target="parser_bug")]
+    out = recover_pointer_sections(_metadata(), sections, tmp_path)
+    assert out[0].recovered_via == RECOVERED_VIA_FILING_SUMMARY
+    assert "Consolidated Income Statement" in out[0].text
+
+
+def test_recover_parser_bug_gracefully_skips_when_no_filing_summary(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """True parser bugs (PWR business='and', MSFT TOC fragments) typically
+    don't have FilingSummary entries that match — recovery attempts but
+    finds nothing, leaves the section unchanged with recovered_via=None."""
+    _patch_recovery_http(monkeypatch, summary_status=404)
     sections = [_pointer_section(target="parser_bug")]
     out = recover_pointer_sections(_metadata(), sections, tmp_path)
     assert out[0].recovered_via is None
-    assert captured["urls"] == []
+    assert out[0].is_pointer_only is True  # provenance preserved
+    assert out[0].text == sections[0].text  # unchanged
 
 
 def test_recover_no_op_when_no_recoverable_sections(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_secrag_sections.py
+++ b/tests/test_secrag_sections.py
@@ -193,12 +193,12 @@ SUBSTANTIVE_RISK_FACTORS = (
         (KO_ITEM11_POINTER, True, "def14a"),
         (IBM_ITEM8_POINTER, True, "annual_report_same_doc"),
         (IBM_ITEM7_POINTER, True, "annual_report_same_doc"),
-        # Varied phrasings the Zo found in real 10-Ks (length-only detection
-        # catches all of these; classification falls back to "unknown" when
-        # neither annual-report nor def14a patterns match)
-        (KO_ITEM8_POINTER_VARIED, True, "unknown"),
-        (NVDA_ITEM8_POINTER_VARIED, True, "unknown"),
-        (INTC_ITEM8_POINTER_TERSE, True, "unknown"),
+        # Varied phrasings the canonical Zo found in real 10-Ks. Length-only
+        # detection catches all of these; classification keys on what
+        # pointer-language tokens are present.
+        (KO_ITEM8_POINTER_VARIED, True, "unknown"),       # "Refer to..."
+        (NVDA_ITEM8_POINTER_VARIED, True, "unknown"),     # "set forth in..."
+        (INTC_ITEM8_POINTER_TERSE, True, "unknown"),      # "Pages 56-108"
         # Long substantive content stays clean even if it mentions
         # "incorporated by reference" in passing
         (SUBSTANTIVE_RISK_FACTORS, False, None),
@@ -209,10 +209,16 @@ SUBSTANTIVE_RISK_FACTORS = (
             False,
             None,
         ),
-        # Edge case: "Not applicable" is also short → flagged as unknown.
-        # This is the intentional trade-off: a 10-K with literally just "Not
-        # applicable" in a curated section is broken either way.
-        ("Not applicable.", True, "unknown"),
+        # Parser-bug cases the canonical Zo found in real 10-Ks: short
+        # extractor outputs with no pointer-language tokens. These are TOC
+        # fragments / orphan whitespace, not real pointers — Phase 2 should
+        # skip recovery on them.
+        ("and", True, "parser_bug"),                                # PWR business=3 chars
+        ("3\n\nInformation about our Executive Officers\n\n14", True, "parser_bug"),  # MSFT TOC
+        # "Not applicable" — also short, no pointer language → parser bug.
+        # A 10-K with literally "Not applicable" in a curated section is
+        # broken either way; flagging it as parser_bug is the right behavior.
+        ("Not applicable.", True, "parser_bug"),
     ],
 )
 def test_detect_pointer_classifies_pointer_and_target(body, expected_pointer, expected_target) -> None:

--- a/tests/test_secrag_sections.py
+++ b/tests/test_secrag_sections.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import pytest
+
 from ai_buffett_zo.secrag import (
     extract_sections,
     extract_sections_from_text,
     html_to_text,
 )
+from ai_buffett_zo.secrag.sections import _detect_pointer
 
 
 SAMPLE_10K_HTML = """
@@ -123,3 +126,129 @@ def test_section_offsets_in_doc_order() -> None:
     sections = extract_sections(SAMPLE_10K_HTML)
     starts = [s.char_start for s in sections]
     assert starts == sorted(starts)
+
+
+# ---- Pointer detection (issue #26) ----------------------------------------
+
+
+# Paraphrased sentences from real 10-K filings. Lengths match live
+# measurements on cis.zo.computer's indexed filings (2026-05-20):
+# - IBM/RKLB Item 7/8 pointers: 220-376 chars (canonical "incorporated by reference" phrasing)
+# - KO/NVDA/INTC/FSLR/NFLX/TSLA/DECK Item 8 pointers: 37-356 chars (varied phrasing — "Refer to...", "set forth in...", page numbers)
+# - Real legitimate substantive sections in the same dataset start at ~540 chars
+# Detection is length-only; phrase patterns only classify the target.
+
+
+KO_ITEM11_POINTER = (
+    "The information required by this Item is incorporated herein by reference "
+    "to the information set forth under the captions 'Executive Compensation' "
+    "and 'Compensation Discussion and Analysis' in the Company's definitive "
+    "Proxy Statement on Schedule 14A for the 2025 Annual Meeting of Shareowners."
+)
+
+IBM_ITEM8_POINTER = (
+    "The financial statements and supplementary data required by this Item are "
+    "included in the Annual Report to Stockholders filed as Exhibit 13 to this "
+    "Form 10-K and are incorporated herein by reference."
+)
+
+IBM_ITEM7_POINTER = (
+    "The information required by Item 7 is included in the Annual Report to "
+    "Stockholders filed as Exhibit 13 of this Form 10-K, which is incorporated "
+    "herein by reference."
+)
+
+# KO uses "Refer to..." phrasing — no incorporation-by-reference language
+KO_ITEM8_POINTER_VARIED = (
+    "Refer to 'Financial Statements and Supplementary Data' included in this "
+    "report. The consolidated financial statements and accompanying notes "
+    "begin on page F-1 of this Form 10-K."
+)
+
+# NVDA uses "is set forth in" phrasing — also no incorporation phrase
+NVDA_ITEM8_POINTER_VARIED = (
+    "The information required by this Item is set forth in our Consolidated "
+    "Financial Statements and accompanying notes."
+)
+
+# INTC's Item 8 is essentially a page reference
+INTC_ITEM8_POINTER_TERSE = "and Supplementary Data Pages 56-108"
+
+SUBSTANTIVE_RISK_FACTORS = (
+    "Our business is concentrated in a small number of high-value contracts; "
+    "the loss of any one of them could materially impact revenue. "
+    "Approximately 35 percent of total revenue in fiscal 2024 came from our "
+    "top three customers. Our supply chain depends on a single fabrication "
+    "partner for advanced-node manufacturing, exposing us to disruption from "
+    "geopolitical events, natural disasters, or capacity constraints at that "
+    "partner. We do not currently have second-source agreements in place for "
+    "our highest-volume products. " * 2  # >500 chars total
+)
+
+
+@pytest.mark.parametrize(
+    ("body", "expected_pointer", "expected_target"),
+    [
+        # Canonical IBM/KO cases with "incorporated by reference" phrasing
+        (KO_ITEM11_POINTER, True, "def14a"),
+        (IBM_ITEM8_POINTER, True, "annual_report_same_doc"),
+        (IBM_ITEM7_POINTER, True, "annual_report_same_doc"),
+        # Varied phrasings the Zo found in real 10-Ks (length-only detection
+        # catches all of these; classification falls back to "unknown" when
+        # neither annual-report nor def14a patterns match)
+        (KO_ITEM8_POINTER_VARIED, True, "unknown"),
+        (NVDA_ITEM8_POINTER_VARIED, True, "unknown"),
+        (INTC_ITEM8_POINTER_TERSE, True, "unknown"),
+        # Long substantive content stays clean even if it mentions
+        # "incorporated by reference" in passing
+        (SUBSTANTIVE_RISK_FACTORS, False, None),
+        (
+            "Our debt agreements contain financial covenants. "
+            "The risk-weighted assets calculation methodology is incorporated "
+            "herein by reference to the Basel III framework. " + "x" * 600,
+            False,
+            None,
+        ),
+        # Edge case: "Not applicable" is also short → flagged as unknown.
+        # This is the intentional trade-off: a 10-K with literally just "Not
+        # applicable" in a curated section is broken either way.
+        ("Not applicable.", True, "unknown"),
+    ],
+)
+def test_detect_pointer_classifies_pointer_and_target(body, expected_pointer, expected_target) -> None:
+    is_pointer, target = _detect_pointer(body)
+    assert is_pointer is expected_pointer
+    assert target == expected_target
+
+
+def test_pointer_detection_propagates_to_extracted_section() -> None:
+    """End-to-end: a curated 10-K extraction surfaces is_pointer_only on the right section."""
+    text = (
+        "Item 1. Business\n"
+        + "We sell things. " * 80  # substantive
+        + "\n\n"
+        + "Item 1A. Risk Factors\n"
+        + "Things could go wrong. " * 80  # substantive
+        + "\n\n"
+        + "Item 7. Management's Discussion and Analysis\n"
+        + IBM_ITEM7_POINTER
+        + "\n\n"
+        + "Item 8. Financial Statements\n"
+        + IBM_ITEM8_POINTER
+        + "\n\n"
+        + "Item 9. Changes in Accountants\nNone.\n"
+    )
+    sections = extract_sections_from_text(text)
+    by_label = {s.label: s for s in sections}
+
+    # Pointer sections flagged correctly
+    assert by_label["mdna"].is_pointer_only is True
+    assert by_label["mdna"].pointer_target == "annual_report_same_doc"
+    assert by_label["financial_statements"].is_pointer_only is True
+    assert by_label["financial_statements"].pointer_target == "annual_report_same_doc"
+
+    # Substantive sections stay clean
+    assert by_label["business"].is_pointer_only is False
+    assert by_label["business"].pointer_target is None
+    assert by_label["risk_factors"].is_pointer_only is False
+    assert by_label["risk_factors"].pointer_target is None


### PR DESCRIPTION
**Supersedes #29** (auto-closed when its base branch `feat/sec-indexer-pointer-recovery` was deleted on the Phase 0 merge — GitHub won't let a closed PR's base be retargeted). Same branch, same commits, now correctly based on `main` with #28 / #31 / #32 merged in. The canonical Zo's real-data validation lives on the [old #29 thread](https://github.com/jingerzz/clarion-intelligence-system/pull/29).

## Summary

When Phase 0 ([#28](https://github.com/jingerzz/clarion-intelligence-system/pull/28), now merged) flags an Item 7 / Item 8 as a pointer, the indexer fetches the SEC `FilingSummary.xml` manifest, identifies every `MenuCategory="Statements"` report, fetches the rendered `R{n}.htm` statement files, and uses those as the section content instead of the pointer text.

**End-to-end impact: `evaluate IBM / KO / NVDA` returns real Consolidated Income Statement / Balance Sheet / Cash Flows numbers instead of "see the Annual Report."**

## Canonical Zo validation (from #29 thread)

All three issue #26 reference cases recover cleanly on the final commit:

| Ticker | Result |
|---|---|
| IBM | ✅ 306KB recovered, all 3 statement markers |
| NVDA | ✅ 236KB recovered, all 3 statement markers |
| KO | ✅ 282KB recovered, all 3 markers (after the `parser_bug` → `RECOVERABLE_TARGETS` fix in commit `9d0d23e`) |

## What changed vs. #29

Just the merge of current `main` (Phase 0 squashed + #31 ARS + #32 TOC) into the branch. Conflicts resolved:
- `tree.py` / `search.py` / `storage.py`: kept Phase 2's `recovered_via` field additions (main only had Phase 0 there)
- `sections.py`: kept both #32's TOC-aware retry constants/logic AND Phase 2's `recovered_via` field — the `_curated_pass` helper calls `_detect_pointer` so all three features coexist
- `tests/test_secrag_sections.py`: took main's superset (Phase 0 pointer tests + #32 TOC tests)

## Files

| File | Change |
|---|---|
| `lib/ai_buffett_zo/secrag/loader.py` | `FilingSummary` types, `fetch_filing_summary_raw` / `fetch_filing_summary` / `fetch_r_file`, `_parse_filing_summary` |
| `lib/ai_buffett_zo/secrag/storage.py` | Cache layer for FilingSummary.xml + R-files; `recovered_via` persistence |
| `lib/ai_buffett_zo/secrag/recovery.py` (new) | `recover_pointer_sections` orchestrator; `RECOVERABLE_TARGETS` includes `parser_bug` per Zo review |
| `lib/ai_buffett_zo/secrag/{sections,tree,search}.py` | `recovered_via` field propagation |
| `lib/ai_buffett_zo/indexer/main.py` | Calls recovery after extraction, before tree build; wrapped in try/except |
| `tests/test_secrag_recovery.py` (new) | 23 tests |

## Test plan

- [x] 687 tests pass on the merged branch (includes Phase 0, Phase 2, #31, #32 suites together)
- [x] Ruff clean
- [x] Canonical Zo real-data validation: IBM / KO / NVDA all recover (see #29 thread)
- [ ] Post-merge: re-run `clarion-setup` on canonical Zo, re-index IBM/KO/NVDA, confirm `evaluate` returns real financials

## Follow-ups

- #35 (mdna and financial_statements get identical recovered text — P2 quality improvement)
- Phase 1 (DEF 14A auto-enqueue for `def14a` targets — only RKLB observed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)