### PR TITLE
feat: workflow timing instrumentation (issue #42)

### DIFF
--- a/lib/ai_buffett_zo/indexer/main.py
+++ b/lib/ai_buffett_zo/indexer/main.py
@@ -39,6 +39,7 @@ from ai_buffett_zo.indexer.status import (
     save_status,
 )
 from ai_buffett_zo.llm import DEFAULT_MODEL_INDEX, ZoClient
+from ai_buffett_zo.observability import Timing
 from ai_buffett_zo.secrag import (
     DEFAULT_SEC_ROOT,
     FilingNotFound,
@@ -114,11 +115,17 @@ def process_one(
     status.update_request(form=form, state="running")
     save_status(sec_root, status)
 
+    # Per-filing timing (issue #42): record each pipeline stage so the
+    # service log reveals where indexing time goes (fetch vs. LLM tree-build
+    # is the usual split). Emitted as one structured line on success.
+    timing = Timing()
+
     try:
-        if accession:
-            metadata, html = fetch_filing_by_accession(ticker, accession)
-        else:
-            metadata, html = fetch_filing(ticker, form=form)
+        with timing.stage("fetch"):
+            if accession:
+                metadata, html = fetch_filing_by_accession(ticker, accession)
+            else:
+                metadata, html = fetch_filing(ticker, form=form)
 
         if is_indexed(sec_root, ticker, metadata.accession):
             logger.info("already indexed: %s %s", ticker, metadata.accession)
@@ -130,12 +137,13 @@ def process_one(
         save_raw(sec_root, metadata, html)
         # Form-aware routing: 10-K/10-Q → curated extraction; everything else
         # (S-1, DEF 14A, Form 4 XML, etc.) → generic markdown-heading extraction.
-        content_type = detect_content_type(metadata.primary_doc)
-        sections = extract_sections_for_form(
-            html,
-            form=metadata.form,
-            content_type=content_type,
-        )
+        with timing.stage("extract"):
+            content_type = detect_content_type(metadata.primary_doc)
+            sections = extract_sections_for_form(
+                html,
+                form=metadata.form,
+                content_type=content_type,
+            )
         if not sections:
             raise ValueError(
                 f"no sections extracted from {ticker} {form} (content_type={content_type})"
@@ -147,28 +155,31 @@ def process_one(
         # substantive statements. Wrapped in try/except so a network failure
         # doesn't break indexing — pointer flag stays True, recovered_via
         # stays None, search layer surfaces the gap.
-        try:
-            sections = recover_pointer_sections(metadata, sections, sec_root)
-        except Exception as e:  # noqa: BLE001
-            logger.warning(
-                "Phase 2 recovery failed for %s %s; continuing with pointer text: %s",
-                ticker, metadata.accession, e,
-            )
+        with timing.stage("recovery"):
+            try:
+                sections = recover_pointer_sections(metadata, sections, sec_root)
+            except Exception as e:  # noqa: BLE001
+                logger.warning(
+                    "Phase 2 recovery failed for %s %s; continuing with pointer text: %s",
+                    ticker, metadata.accession, e,
+                )
 
         # Decide indexing path: full LLM-summarized tree (10-K, S-1, etc.) vs
         # raw single-node fallback (8-K, Form 4, etc.). Token-count safety net
         # forces a full index when a normally-raw form runs unusually long.
         total_tokens = sum(len(s.text) for s in sections) // 4
-        if should_full_index(metadata.form, total_tokens):
-            builder = TreeBuilder(client, model=model)
-            tree = builder.build(metadata, sections)
-        else:
-            tree = build_raw_tree(metadata, sections)
-            logger.info(
-                "raw-stored %s %s (form not in full-index allowlist; %d tokens)",
-                ticker, metadata.accession, total_tokens,
-            )
-        save_tree(sec_root, tree)
+        with timing.stage("tree-build"):
+            if should_full_index(metadata.form, total_tokens):
+                builder = TreeBuilder(client, model=model)
+                tree = builder.build(metadata, sections)
+            else:
+                tree = build_raw_tree(metadata, sections)
+                logger.info(
+                    "raw-stored %s %s (form not in full-index allowlist; %d tokens)",
+                    ticker, metadata.accession, total_tokens,
+                )
+        with timing.stage("save"):
+            save_tree(sec_root, tree)
 
         status.merge_filing(
             FilingStatus(
@@ -188,6 +199,13 @@ def process_one(
             metadata.accession,
             len(sections),
             sum(1 for s in tree.sections if s.chunks),
+        )
+        # Compact per-stage timing on one line, keyed by form so logs can be
+        # grepped/aggregated by form type (issue #42).
+        stage_str = " ".join(f"{name}={secs:.1f}s" for name, secs in timing.stages)
+        logger.info(
+            "timing %s %s form=%s total=%.1fs %s",
+            ticker, metadata.accession, metadata.form, timing.total(), stage_str,
         )
 
     except FilingNotFound as e:

--- a/lib/ai_buffett_zo/observability/__init__.py
+++ b/lib/ai_buffett_zo/observability/__init__.py
@@ -1,0 +1,13 @@
+"""Lightweight observability helpers for Clarion workflows.
+
+Currently exposes ``Timing`` — a small stage-timer for identifying latency
+bottlenecks in long-running commands (single-stock eval, SEC indexer). See
+issue #42 for the motivation: measure where the time goes before investing
+in indexing profiles, queue priority, caching, or persona fast paths.
+"""
+
+from __future__ import annotations
+
+from ai_buffett_zo.observability.timing import Timing
+
+__all__ = ["Timing"]

--- a/lib/ai_buffett_zo/observability/timing.py
+++ b/lib/ai_buffett_zo/observability/timing.py
@@ -1,0 +1,88 @@
+"""Stage timer for Clarion workflows (issue #42).
+
+A ``Timing`` accumulates named stage durations so long-running commands can
+emit a compact "where did the time go" summary:
+
+    Timing:
+    - yfinance snapshot: 1.2s
+    - regime check: 0.8s
+    - SEC status: 0.1s
+    - Buffett lens search: 2.4s
+    Total: 4.5s
+
+Two ways to record a stage:
+
+- ``with t.stage("name"): ...`` — times the block, always records even if the
+  block raises (so a failure still shows up in the summary).
+- ``t.record("name", seconds)`` — for durations measured elsewhere (e.g. a
+  subprocess that reports its own wall time).
+
+The class is deliberately dependency-free and side-effect-free: it never
+prints on its own. Callers decide whether/where to surface ``summary()``
+(stderr for CLIs, the service log for the indexer). That keeps timing opt-in
+and out of the way of structured stdout that other tools parse.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Timing:
+    """Accumulates named stage durations for one workflow run.
+
+    ``stages`` preserves insertion order — the summary reads top-to-bottom in
+    the order stages actually ran, which is what a human debugging latency
+    wants to see.
+    """
+
+    stages: list[tuple[str, float]] = field(default_factory=list)
+    # perf_counter is monotonic — immune to wall-clock adjustments mid-run.
+    _start: float = field(default_factory=time.perf_counter)
+
+    @contextmanager
+    def stage(self, name: str) -> Iterator[None]:
+        """Time a block of work, recording its duration under ``name``.
+
+        Records even when the block raises, so a failing stage still appears
+        in the summary (with the time spent before it blew up).
+        """
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            self.stages.append((name, time.perf_counter() - start))
+
+    def record(self, name: str, seconds: float) -> None:
+        """Record a stage duration measured outside this timer."""
+        self.stages.append((name, seconds))
+
+    def total(self) -> float:
+        """Wall time since this Timing was constructed."""
+        return time.perf_counter() - self._start
+
+    def summary(self, *, title: str = "Timing") -> str:
+        """Render the compact multi-line summary.
+
+        Always ends with a ``Total`` line measured from construction — which
+        can exceed the sum of recorded stages (uninstrumented gaps) or fall
+        short of it (overlapping/externally-recorded stages). The gap itself
+        is a useful signal when debugging.
+        """
+        lines = [f"{title}:"]
+        for name, secs in self.stages:
+            lines.append(f"- {name}: {secs:.1f}s")
+        lines.append(f"Total: {self.total():.1f}s")
+        return "\n".join(lines)
+
+    def as_dict(self) -> dict[str, float]:
+        """Stage durations as a dict (last write wins on duplicate names).
+
+        Handy for tests and for structured logging where a human-readable
+        summary isn't wanted.
+        """
+        return dict(self.stages)

--- a/skills/clarion-single-stock-eval/SKILL.md
+++ b/skills/clarion-single-stock-eval/SKILL.md
@@ -41,7 +41,10 @@ EVAL=python /home/workspace/clarion-intelligence-system/skills/clarion-single-st
 $EVAL NVDA                       # default — pulls all four dimensions
 $EVAL NVDA --rf-rate-pct 4.5     # adds equity hurdle to market context
 $EVAL NVDA --no-regime           # skip regime/hurdle if user just wants the lens
+$EVAL NVDA --timing              # also print a per-stage latency summary to stderr
 ```
+
+**Diagnosing slow evals.** If an evaluation feels slow, re-run with `--timing`. It prints a per-stage breakdown to stderr (SEC status / yfinance snapshot / regime check / Buffett lens search / render) so you can see where the time goes — without polluting the markdown the agent reasons over. Pairs with the `sec-indexer` per-filing `timing …` log lines for the indexing side. See issue #42.
 
 ## Voice
 

--- a/skills/clarion-single-stock-eval/scripts/eval.py
+++ b/skills/clarion-single-stock-eval/scripts/eval.py
@@ -31,6 +31,7 @@ from ai_buffett_zo.evaluation import (
     fetch_fundamentals,
     view as lens_view,
 )
+from ai_buffett_zo.observability import Timing
 from ai_buffett_zo.regime import HURDLE_PREMIUM_PCT, RegimeSnapshot, snapshot
 from ai_buffett_zo.secrag import DEFAULT_SEC_ROOT, list_indexed
 from ai_buffett_zo.voice import (
@@ -50,8 +51,10 @@ def sec_root() -> Path:
 def run(args: argparse.Namespace) -> int:
     ticker = args.ticker.upper()
     sroot = sec_root()
+    timing = Timing()
 
-    indexed = [m for m in list_indexed(sroot) if m.ticker == ticker]
+    with timing.stage("SEC status"):
+        indexed = [m for m in list_indexed(sroot) if m.ticker == ticker]
     if not indexed:
         print(header(f"Single-Stock Evaluation — {ticker}"))
         print()
@@ -60,19 +63,41 @@ def run(args: argparse.Namespace) -> int:
         print(f"Run `clarion-sec-research index {ticker}` first, wait for completion, then retry.")
         print()
         print(footer())
+        _emit_timing(args, timing)
         return 0
 
     try:
-        f = fetch_fundamentals(ticker)
+        with timing.stage("yfinance snapshot"):
+            f = fetch_fundamentals(ticker)
     except Exception as e:  # noqa: BLE001
         print(f"EVAL_ERROR: failed to fetch fundamentals for {ticker}: {type(e).__name__}: {e}")
+        _emit_timing(args, timing)
         return 1
 
-    regime_snap = None if args.no_regime else _maybe_regime(args.rf_rate_pct)
-    lens = lens_view(ticker, sec_root=sroot)
+    if args.no_regime:
+        regime_snap = None
+    else:
+        with timing.stage("regime check"):
+            regime_snap = _maybe_regime(args.rf_rate_pct)
 
-    _render(f, regime_snap, lens, indexed_accessions=[m.accession for m in indexed])
+    with timing.stage("Buffett lens search"):
+        lens = lens_view(ticker, sec_root=sroot)
+
+    with timing.stage("render"):
+        _render(f, regime_snap, lens, indexed_accessions=[m.accession for m in indexed])
+
+    _emit_timing(args, timing)
     return 0
+
+
+def _emit_timing(args: argparse.Namespace, timing: Timing) -> None:
+    """Print the timing summary to stderr when --timing is set.
+
+    stderr (not stdout) so the structured markdown the chat agent parses
+    stays clean — timing is operator diagnostics, not part of the eval.
+    """
+    if getattr(args, "timing", False):
+        print(timing.summary(title=f"Timing ({args.ticker.upper()})"), file=sys.stderr)
 
 
 def _maybe_regime(rf_rate_pct: float | None) -> RegimeSnapshot | None:
@@ -249,6 +274,11 @@ def main() -> int:
         "--no-regime",
         action="store_true",
         help="Skip regime/hurdle calculation (fundamentals + lens only).",
+    )
+    ap.add_argument(
+        "--timing",
+        action="store_true",
+        help="Emit a per-stage timing summary to stderr (issue #42 — latency diagnostics).",
     )
     args = ap.parse_args()
     return run(args)

--- a/tests/test_eval_skill.py
+++ b/tests/test_eval_skill.py
@@ -124,8 +124,16 @@ def _patch_pipeline(
     monkeypatch.setattr(eval_mod, "_maybe_regime", lambda rf: regime)
 
 
-def _args(ticker: str = "NVDA", *, rf: float | None = None, no_regime: bool = False):
-    return argparse.Namespace(ticker=ticker, rf_rate_pct=rf, no_regime=no_regime)
+def _args(
+    ticker: str = "NVDA",
+    *,
+    rf: float | None = None,
+    no_regime: bool = False,
+    timing: bool = False,
+):
+    return argparse.Namespace(
+        ticker=ticker, rf_rate_pct=rf, no_regime=no_regime, timing=timing
+    )
 
 
 # ---- run() ------------------------------------------------------------------
@@ -195,6 +203,47 @@ def test_run_with_no_regime_skips_market_context(
     assert "ORANGE" not in out
     # Reading guide should NOT have the hurdle question (#5)
     assert "Hurdle clearance" not in out
+
+
+def test_run_timing_flag_emits_summary_to_stderr(
+    eval_mod,
+    sec_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--timing prints a per-stage summary to stderr (issue #42); stdout stays clean."""
+    _save_filing(sec_root, "NVDA", [("business", "Brief.")])
+    _patch_pipeline(eval_mod, monkeypatch, regime=_regime("green", 7.0))
+
+    rc = eval_mod.run(_args("NVDA", rf=4.5, timing=True))
+    assert rc == 0
+    captured = capsys.readouterr()
+
+    # Timing goes to stderr, not stdout
+    assert "Timing (NVDA):" in captured.err
+    assert "SEC status" in captured.err
+    assert "yfinance snapshot" in captured.err
+    assert "regime check" in captured.err
+    assert "Buffett lens search" in captured.err
+    assert "Total:" in captured.err
+    # stdout has the eval, not the timing block
+    assert "Timing (NVDA):" not in captured.out
+
+
+def test_run_without_timing_flag_emits_nothing_to_stderr(
+    eval_mod,
+    sec_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Default (no --timing): no timing noise anywhere."""
+    _save_filing(sec_root, "NVDA", [("business", "Brief.")])
+    _patch_pipeline(eval_mod, monkeypatch, regime=_regime("green", 7.0))
+
+    eval_mod.run(_args("NVDA", rf=4.5, timing=False))
+    captured = capsys.readouterr()
+    assert "Timing" not in captured.err
+    assert "Timing" not in captured.out
 
 
 def test_run_with_rf_includes_hurdle(

--- a/tests/test_indexer_main.py
+++ b/tests/test_indexer_main.py
@@ -310,6 +310,42 @@ def test_process_one_returns_silently_when_request_id_missing(
     # No raise, no files created (queue/sec dirs may be created by status logging — that's fine)
 
 
+# ---- per-filing timing (issue #42) ----------------------------------------
+
+
+def test_process_one_emits_timing_log_line(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A successful index emits one compact per-stage timing line, keyed by form."""
+    queue_root = tmp_path / "queue"
+    sec_root = tmp_path / "sec"
+    _patch_pipeline(monkeypatch)
+
+    r = IndexRequest.new("NVDA", "10-K")
+    enqueue(r, root=queue_root)
+
+    with caplog.at_level(logging.INFO, logger="test_indexer"):
+        main_mod.process_one(
+            r.id,
+            queue_root=queue_root,
+            sec_root=sec_root,
+            client=ZoClient(token="zo_sk_test"),
+            default_model="zo:openai/gpt-5.4-mini",
+            logger=_logger(),
+        )
+
+    timing_lines = [m for m in caplog.messages if m.startswith("timing ")]
+    assert len(timing_lines) == 1
+    line = timing_lines[0]
+    # Keyed by ticker, accession, form; carries total + each stage
+    assert "NVDA" in line
+    assert "acc-1" in line
+    assert "form=10-K" in line
+    assert "total=" in line
+    for stage in ("fetch=", "extract=", "recovery=", "tree-build=", "save="):
+        assert stage in line, f"missing {stage} in timing line: {line}"
+
+
 # ---- run_loop --------------------------------------------------------------
 
 

--- a/tests/test_observability_timing.py
+++ b/tests/test_observability_timing.py
@@ -1,0 +1,86 @@
+"""Tests for ai_buffett_zo.observability.timing."""
+
+from __future__ import annotations
+
+import pytest
+
+from ai_buffett_zo.observability import Timing
+
+
+def test_stage_records_duration() -> None:
+    t = Timing()
+    with t.stage("work"):
+        pass
+    assert len(t.stages) == 1
+    name, secs = t.stages[0]
+    assert name == "work"
+    assert secs >= 0.0
+
+
+def test_stages_preserve_order() -> None:
+    t = Timing()
+    with t.stage("first"):
+        pass
+    with t.stage("second"):
+        pass
+    with t.stage("third"):
+        pass
+    assert [name for name, _ in t.stages] == ["first", "second", "third"]
+
+
+def test_stage_records_even_on_exception() -> None:
+    """A failing stage still shows up in the summary — that's the point."""
+    t = Timing()
+    with pytest.raises(ValueError):
+        with t.stage("boom"):
+            raise ValueError("kaboom")
+    assert [name for name, _ in t.stages] == ["boom"]
+
+
+def test_record_external_duration() -> None:
+    t = Timing()
+    t.record("subprocess wall time", 12.5)
+    assert t.as_dict()["subprocess wall time"] == 12.5
+
+
+def test_total_is_monotonic_nonnegative() -> None:
+    t = Timing()
+    assert t.total() >= 0.0
+
+
+def test_summary_format() -> None:
+    t = Timing()
+    t.record("yfinance snapshot", 1.2)
+    t.record("regime check", 0.8)
+    summary = t.summary()
+    lines = summary.splitlines()
+    assert lines[0] == "Timing:"
+    assert lines[1] == "- yfinance snapshot: 1.2s"
+    assert lines[2] == "- regime check: 0.8s"
+    assert lines[-1].startswith("Total: ")
+    assert lines[-1].endswith("s")
+
+
+def test_summary_custom_title() -> None:
+    t = Timing()
+    t.record("fetch", 2.0)
+    summary = t.summary(title="IBM 10-K indexing")
+    assert summary.startswith("IBM 10-K indexing:")
+
+
+def test_summary_empty_has_title_and_total() -> None:
+    t = Timing()
+    summary = t.summary()
+    lines = summary.splitlines()
+    assert lines[0] == "Timing:"
+    assert lines[1].startswith("Total: ")
+
+
+def test_as_dict_last_write_wins() -> None:
+    """Duplicate stage names collapse — last duration wins in the dict view."""
+    t = Timing()
+    t.record("fetch", 1.0)
+    t.record("fetch", 3.0)
+    assert t.as_dict()["fetch"] == 3.0
+    # But stages list keeps both for the ordered summary
+    assert len(t.stages) == 2


### PR DESCRIPTION
Closes #42.

## Summary

Clarion sometimes feels slow, but the UX doesn't reveal where the time goes. This adds a lightweight measurement layer so we know the actual bottleneck **before** investing in the other performance issues (#37/#38/#39/#40/#41). Per #42's own framing: measure first, optimize second.

## What's added

**New `lib/ai_buffett_zo/observability/Timing`** — a dependency-free stage timer:
- `with t.stage("name"): ...` times a block (records even if it raises)
- `t.record(name, secs)` for externally-measured durations
- `t.summary()` renders the compact format from the issue
- Never prints on its own — callers decide where to surface it (stderr for CLIs, service log for the indexer)

**`eval.py --timing`** — wraps the five eval stages and prints a per-stage summary to **stderr**:

```
Timing (IBM):
- SEC status: 0.1s
- yfinance snapshot: 1.2s
- regime check: 0.8s
- Buffett lens search: 2.4s
- render: 0.0s
Total: 4.5s
```

stdout stays clean so the chat agent's markdown parsing is unaffected. Default off.

**Indexer per-filing timing** — `process_one` times each pipeline stage and emits one compact line on success, keyed by form so logs can be aggregated by form type:

```
timing IBM 0000051143-26-000010 form=10-K total=94.0s fetch=2.1s extract=0.8s recovery=11.3s tree-build=79.2s save=0.6s
```

Always-on (the service log is the indexer's observability surface). This directly answers the issue's "per-filing timing and form type" ask and will confirm whether LLM tree-build dominates — informing #37/#39/#40.

## Why these two surfaces

They're exactly the measurements needed to prioritize the rest of the performance cluster:
- **Indexer timing** → is SEC indexing the bottleneck? which forms/stages are slow? → informs #37 (profiles), #39 (priority), #40 (low-signal deferral)
- **Eval stage timing** → how much of a slow eval is indexing-wait vs. search vs. yfinance? → informs #38 (eval-ready) and #41 (persona fast path)

Remaining stages from the issue (regime internals, search internals, thesis validation) can be instrumented incrementally with the same `Timing` primitive as needed.

## Files

| File | Change |
|---|---|
| `lib/ai_buffett_zo/observability/{__init__,timing}.py` (new) | `Timing` primitive |
| `skills/clarion-single-stock-eval/scripts/eval.py` | `--timing` flag, stage wrapping, stderr summary |
| `skills/clarion-single-stock-eval/SKILL.md` | Documents `--timing` + the indexer timing log lines |
| `lib/ai_buffett_zo/indexer/main.py` | Per-filing per-stage timing log line |
| `tests/test_observability_timing.py` (new) | 9 Timing unit tests |
| `tests/test_eval_skill.py` | 2 tests (--timing → stderr; default → silent) |
| `tests/test_indexer_main.py` | 1 test (per-filing timing line, all stages, keyed by form) |

## Test plan

- [x] 699 tests pass (12 new)
- [x] Ruff clean
- [x] eval `--timing` writes to stderr, not stdout (verified by test)
- [x] indexer timing line includes all five stages + form + total (verified by test)
- [ ] Post-merge: on canonical Zo, run `evaluate IBM` style flow + check `tail /dev/shm/sec-indexer.log` for `timing …` lines on the next index, then use that data to prioritize #37-41

## No registry PR needed

Touches `lib/` + a sibling skill (`clarion-single-stock-eval`) — both propagate via `git pull` on `set up Clarion`. `clarion-setup` (the only registry-served skill) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)