### PR TITLE
feat: strip iXBRL framework metadata from recovered R-file text (issue #43)

### DIFF
--- a/lib/ai_buffett_zo/secrag/recovery.py
+++ b/lib/ai_buffett_zo/secrag/recovery.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+import re
 from pathlib import Path
 
 from ai_buffett_zo.secrag.loader import (
@@ -175,6 +176,51 @@ def _get_or_fetch_summary(
     return _parse_filing_summary(raw_xml)
 
 
+# iXBRL framework metadata that SEC's R-file renderer interleaves with the
+# actual statement figures. These lines carry no analytical value and pollute
+# downstream search — qualitative queries (moat, management) end up ranking
+# taxonomy boilerplate above narrative. Patterns derive from the canonical
+# Zo's observation on IBM R-files (issue #43): element type descriptors,
+# period-type labels, definition markers, and taxonomy URIs.
+#
+# CONSERVATIVE by design: the filter drops a line only when it clearly matches
+# a metadata signature, and never touches a data row (label + numeric
+# columns). Worst case it under-strips (some noise survives) — never
+# over-strips real figures.
+#
+# NOTE (issue #43): pattern set is tuned against the Zo's described format and
+# should be validated against real R-file text before relying on completeness.
+# Add patterns here as new noise shapes surface; the structure makes that a
+# one-line change.
+_XBRL_NOISE_LINE_RE = re.compile(
+    r"^\s*(?:"
+    r"type:\s*(?:credit|debit)\b"                 # element balance type
+    r"|period\s*type:\s*(?:duration|instant)\b"   # element period type
+    r"|x\s*[-–—]\s*definition\b"                   # iXBRL "X — Definition" marker
+    r"|no\s+definition\s+available\.?\s*$"         # placeholder definition row
+    r"|definition\s*$"                             # bare "Definition" label line
+    r"|https?://\S*(?:xbrl|fasb\.org|sec\.gov/CIK)\S*"  # taxonomy / namespace URIs
+    r")",
+    re.IGNORECASE,
+)
+
+
+def _strip_xbrl_metadata(text: str) -> str:
+    """Drop iXBRL framework-metadata lines from rendered R-file text (issue #43).
+
+    SEC's iXBRL renderer interleaves element definitions, balance/period-type
+    descriptors, and taxonomy URIs with the statement figures. They survive
+    ``html_to_text`` and degrade search precision. This conservative line
+    filter removes only lines matching clear metadata signatures
+    (``_XBRL_NOISE_LINE_RE``) and collapses the blank-line runs a removed
+    block leaves behind. Data rows and any unrecognized line pass through
+    untouched.
+    """
+    kept = [ln for ln in text.splitlines() if not _XBRL_NOISE_LINE_RE.match(ln)]
+    cleaned = re.sub(r"\n{3,}", "\n\n", "\n".join(kept))
+    return cleaned.strip()
+
+
 def _assemble_recovered_text(
     metadata: FilingMetadata,
     statements: list,  # list[FilingSummaryReport]
@@ -182,7 +228,8 @@ def _assemble_recovered_text(
 ) -> str:
     """Fetch + concatenate R-file text for every Statements report.
 
-    Each R-file is fetched once (cache-first). Text is prefixed with a
+    Each R-file is fetched once (cache-first), extracted to text, then
+    stripped of iXBRL framework noise (issue #43). Text is prefixed with a
     ``# ShortName`` heading so downstream readers can tell where one
     statement ends and the next begins.
     """
@@ -195,7 +242,7 @@ def _assemble_recovered_text(
                 report.html_file_name, metadata.ticker, metadata.accession,
             )
             continue
-        text = html_to_text(html)
+        text = _strip_xbrl_metadata(html_to_text(html))
         if not text:
             continue
         pieces.append(f"# {report.short_name}\n\n{text}")

--- a/lib/ai_buffett_zo/secrag/recovery.py
+++ b/lib/ai_buffett_zo/secrag/recovery.py
@@ -176,49 +176,55 @@ def _get_or_fetch_summary(
     return _parse_filing_summary(raw_xml)
 
 
-# iXBRL framework metadata that SEC's R-file renderer interleaves with the
-# actual statement figures. These lines carry no analytical value and pollute
-# downstream search — qualitative queries (moat, management) end up ranking
-# taxonomy boilerplate above narrative. Patterns derive from the canonical
-# Zo's observation on IBM R-files (issue #43): element type descriptors,
-# period-type labels, definition markers, and taxonomy URIs.
-#
-# CONSERVATIVE by design: the filter drops a line only when it clearly matches
-# a metadata signature, and never touches a data row (label + numeric
-# columns). Worst case it under-strips (some noise survives) — never
-# over-strips real figures.
-#
-# NOTE (issue #43): pattern set is tuned against the Zo's described format and
-# should be validated against real R-file text before relying on completeness.
-# Add patterns here as new noise shapes surface; the structure makes that a
-# one-line change.
-_XBRL_NOISE_LINE_RE = re.compile(
-    r"^\s*(?:"
-    r"type:\s*(?:credit|debit)\b"                 # element balance type
-    r"|period\s*type:\s*(?:duration|instant)\b"   # element period type
-    r"|x\s*[-–—]\s*definition\b"                   # iXBRL "X — Definition" marker
-    r"|no\s+definition\s+available\.?\s*$"         # placeholder definition row
-    r"|definition\s*$"                             # bare "Definition" label line
-    r"|https?://\S*(?:xbrl|fasb\.org|sec\.gov/CIK)\S*"  # taxonomy / namespace URIs
-    r")",
+# An R-file's bytes are dominated (80-90% on IBM's R3.htm — ~80KB of an 85KB
+# file) by iXBRL framework metadata that the renderer appends AFTER the
+# financial table: repeating "+ Details" / "X — Definition" / "+ References"
+# blocks carrying element names, namespaces, data types, definition prose,
+# and taxonomy references. Because it all FOLLOWS the table, the cleanest
+# filter is a structural truncation at the first metadata-block delimiter —
+# not line-by-line matching, since the definition *prose* (full sentences) has
+# no line signature and would survive a line filter. Verified against the
+# canonical Zo's IBM R3.htm sample (issue #43).
+_XBRL_METADATA_START_RE = re.compile(
+    r"\n[ \t]*\+[ \t]*Details\b"                                       # "+ Details" block
+    r"|\n[ \t]*\+[ \t]*References\b"                                   # "+ References" block
+    r"|\n[ \t]*X[ \t]*\n[ \t]*-[ \t]*(?:Definition|References|Details)\b",  # "X \n - Definition" marker
+    re.IGNORECASE,
+)
+
+# Leading boilerplate the renderer prepends: "XML / <n> / R<n>.htm /
+# IDEA: XBRL DOCUMENT / v<x.y.z>". Small but pure noise. Anchored to the very
+# start; non-matching text (other filers / layouts) is left untouched.
+_XBRL_PREAMBLE_RE = re.compile(
+    r"\A\s*XML\s*\n\s*\d+\s*\n\s*R\d+\.htm\s*\n\s*IDEA:\s*XBRL\s+DOCUMENT\s*\n\s*v[\d.]+\s*\n",
     re.IGNORECASE,
 )
 
 
 def _strip_xbrl_metadata(text: str) -> str:
-    """Drop iXBRL framework-metadata lines from rendered R-file text (issue #43).
+    """Trim iXBRL framework noise from rendered R-file text (issue #43).
 
-    SEC's iXBRL renderer interleaves element definitions, balance/period-type
-    descriptors, and taxonomy URIs with the statement figures. They survive
-    ``html_to_text`` and degrade search precision. This conservative line
-    filter removes only lines matching clear metadata signatures
-    (``_XBRL_NOISE_LINE_RE``) and collapses the blank-line runs a removed
-    block leaves behind. Data rows and any unrecognized line pass through
-    untouched.
+    Two structural cuts, both conservative (no match → that part untouched):
+
+    1. **Truncate the metadata tail.** Everything from the first
+       "+ Details" / "+ References" / "X — Definition" delimiter to EOF is
+       framework metadata (element definitions, namespaces, taxonomy refs).
+       On IBM's R3.htm that's ~80KB of an 85KB file.
+    2. **Strip the leading preamble** — the "XML / N / R<n>.htm / IDEA: XBRL
+       DOCUMENT / v<x.y.z>" boilerplate the renderer prepends.
+
+    The financial table — which sits between preamble and metadata — is
+    preserved intact, including ``[N]`` footnote markers (kept as row
+    anchors per the canonical Zo's recommendation). If neither pattern
+    matches (unrecognized layout), the text is returned unchanged.
+
+    Validated against the canonical Zo's real IBM R3.htm sample (issue #43).
     """
-    kept = [ln for ln in text.splitlines() if not _XBRL_NOISE_LINE_RE.match(ln)]
-    cleaned = re.sub(r"\n{3,}", "\n\n", "\n".join(kept))
-    return cleaned.strip()
+    text = _XBRL_PREAMBLE_RE.sub("", text, count=1)
+    m = _XBRL_METADATA_START_RE.search(text)
+    if m is not None:
+        text = text[: m.start()]
+    return text.strip()
 
 
 def _assemble_recovered_text(

--- a/tests/test_secrag_recovery.py
+++ b/tests/test_secrag_recovery.py
@@ -431,100 +431,127 @@ def test_parse_filing_summary_tolerates_missing_optional_fields() -> None:
 # ---- iXBRL noise stripping (issue #43) ------------------------------------
 
 
-def test_strip_xbrl_metadata_removes_type_and_period_lines() -> None:
-    """Element balance/period-type descriptor lines are dropped."""
-    text = (
-        "Total revenue\n"
-        "62,753\n"
-        "Type: credit\n"
-        "Period Type: duration\n"
-        "Net income\n"
-        "7,500\n"
-    )
-    out = _strip_xbrl_metadata(text)
-    assert "Type: credit" not in out
-    assert "Period Type: duration" not in out
-    # Real data survives
-    assert "Total revenue" in out
-    assert "62,753" in out
-    assert "Net income" in out
-    assert "7,500" in out
+# Mirrors the real IBM R3.htm structure the canonical Zo captured: a small
+# leading preamble, the financial table (clean, with [N] footnote markers),
+# then the large XBRL framework-metadata tail ("+ Details" / "X - Definition"
+# / "+ References" blocks) that makes up ~80-90% of the file.
+_REAL_RFILE_TEXT = (
+    "XML\n"
+    "27\n"
+    "R3.htm\n"
+    "IDEA: XBRL DOCUMENT\n"
+    "v3.25.4\n"
+    "CONSOLIDATED INCOME STATEMENT - USD ($)\n"
+    "$ in Millions\n"
+    "12 Months Ended\n"
+    "Dec. 31, 2025\n"
+    "Revenue   $ 67,535   $ 62,753   $ 61,860\n"
+    "Cost      28,239     27,201     27,560\n"
+    "Gross profit   39,297   35,551   34,300\n"
+    "Net income [1]   $ 10,593   $ 6,023   $ 7,502\n"
+    "\n"
+    "+ Details\n"
+    "Name:                us-gaap_WeightedAverageNumberOfDilutedSharesOutstanding\n"
+    "Namespace Prefix:    us-gaap_\n"
+    "Data Type:           xbrli:sharesItemType\n"
+    "Balance Type:        na\n"
+    "Period Type:         duration\n"
+    "\n"
+    "X\n"
+    "- Definition\n"
+    "Number of [basic] shares or units, after adjustment for contingently issuable shares...\n"
+    "\n"
+    "+ References\n"
+    "Reference 1: http://www.xbrl.org/2003/role/disclosureRef\n"
+    "-Topic 260\n"
+    "-SubTopic 10\n"
+)
 
 
-def test_strip_xbrl_metadata_removes_definition_markers() -> None:
-    text = (
-        "Cash flows from operations\n"
-        "13,500\n"
-        "X — Definition\n"
-        "No definition available.\n"
-        "Definition\n"
-        "Proceeds from new debt\n"
-        "8,391\n"
-    )
-    out = _strip_xbrl_metadata(text)
-    assert "X — Definition" not in out
-    assert "No definition available" not in out
-    # The bare "Definition" label line is gone, but data rows remain
-    assert "\nDefinition\n" not in f"\n{out}\n"
-    assert "Cash flows from operations" in out
-    assert "13,500" in out
-    assert "Proceeds from new debt" in out
-    assert "8,391" in out
+def test_strip_xbrl_metadata_keeps_financial_table() -> None:
+    """The actual statement figures survive the truncation."""
+    out = _strip_xbrl_metadata(_REAL_RFILE_TEXT)
+    assert "CONSOLIDATED INCOME STATEMENT" in out
+    assert "Revenue   $ 67,535" in out
+    assert "Gross profit" in out
+    assert "Net income [1]" in out  # footnote markers preserved as row anchors
 
 
-def test_strip_xbrl_metadata_removes_taxonomy_uris() -> None:
-    text = (
-        "Total assets\n"
-        "130,000\n"
-        "http://fasb.org/us-gaap/2025#Assets\n"
-        "http://www.xbrl.org/2003/role/label\n"
-        "Total liabilities\n"
-        "110,000\n"
-    )
-    out = _strip_xbrl_metadata(text)
-    assert "fasb.org" not in out
+def test_strip_xbrl_metadata_truncates_framework_tail() -> None:
+    """Everything from the first '+ Details' delimiter onward is removed."""
+    out = _strip_xbrl_metadata(_REAL_RFILE_TEXT)
+    assert "+ Details" not in out
+    assert "Namespace Prefix" not in out
+    assert "Balance Type" not in out
+    assert "Period Type" not in out
+    assert "- Definition" not in out
+    assert "Number of [basic] shares" not in out  # definition prose gone
+    assert "+ References" not in out
     assert "xbrl.org" not in out
-    assert "Total assets" in out
-    assert "130,000" in out
-    assert "Total liabilities" in out
+    assert "-Topic 260" not in out
 
 
-def test_strip_xbrl_metadata_preserves_clean_text() -> None:
-    """Text with no iXBRL noise passes through unchanged (modulo trailing ws)."""
+def test_strip_xbrl_metadata_removes_preamble() -> None:
+    """The 'XML / N / R<n>.htm / IDEA: XBRL DOCUMENT / v<x>' preamble is gone."""
+    out = _strip_xbrl_metadata(_REAL_RFILE_TEXT)
+    assert "IDEA: XBRL DOCUMENT" not in out
+    assert not out.startswith("XML")
+    assert "R3.htm" not in out
+    # The first real line is the statement header
+    assert out.lstrip().startswith("CONSOLIDATED INCOME STATEMENT")
+
+
+def test_strip_xbrl_metadata_truncates_on_x_definition_marker() -> None:
+    """Files whose first delimiter is the bare 'X \\n - Definition' form truncate too."""
+    text = (
+        "BALANCE SHEET\n"
+        "Total assets 130,000\n"
+        "X\n"
+        "- Definition\n"
+        "Carrying amount as of the balance sheet date...\n"
+    )
+    out = _strip_xbrl_metadata(text)
+    assert "Total assets 130,000" in out
+    assert "- Definition" not in out
+    assert "Carrying amount" not in out
+
+
+def test_strip_xbrl_metadata_truncates_on_references_block() -> None:
+    text = (
+        "CASH FLOWS\n"
+        "Operating cash flow 13,500\n"
+        "+ References\n"
+        "Reference 1: http://fasb.org/us-gaap/2025\n"
+    )
+    out = _strip_xbrl_metadata(text)
+    assert "Operating cash flow 13,500" in out
+    assert "+ References" not in out
+    assert "fasb.org" not in out
+
+
+def test_strip_xbrl_metadata_leaves_clean_text_untouched() -> None:
+    """No delimiter, no preamble → returned unchanged (modulo trailing ws)."""
     text = (
         "CONSOLIDATED INCOME STATEMENT\n"
-        "Total revenue 62,753 60,530 57,351\n"
-        "Cost of goods sold (31,000)\n"
-        "Net income 7,500"
+        "Revenue 67,535 62,753 61,860\n"
+        "Net income 10,593 6,023 7,502"
     )
-    out = _strip_xbrl_metadata(text)
-    assert out == text.strip()
+    assert _strip_xbrl_metadata(text) == text.strip()
 
 
-def test_strip_xbrl_metadata_does_not_eat_data_mentioning_credit() -> None:
-    """A real line that happens to contain 'credit' mid-sentence is kept.
+def test_strip_xbrl_metadata_preserves_data_line_mentioning_details() -> None:
+    """A real data line containing 'details' mid-text isn't a delimiter.
 
-    The filter anchors on line-start 'Type: credit', not the word 'credit'
-    anywhere — so revenue/credit-loss line items survive.
+    The delimiter requires '+ Details' at line start; prose mentions survive.
     """
     text = (
-        "Provision for credit losses\n"
-        "1,234\n"
-        "Credit card receivables, net\n"
-        "45,678\n"
+        "Revenue 67,535\n"
+        "See accompanying notes for details of segment revenue.\n"
+        "Net income 10,593\n"
     )
     out = _strip_xbrl_metadata(text)
-    assert "Provision for credit losses" in out
-    assert "Credit card receivables, net" in out
-    assert "1,234" in out
-    assert "45,678" in out
-
-
-def test_strip_xbrl_metadata_collapses_blank_runs() -> None:
-    """Removing a metadata block shouldn't leave 3+ blank lines behind."""
-    text = "Revenue\n100\nType: credit\nPeriod Type: duration\n\n\nNet income\n50"
-    out = _strip_xbrl_metadata(text)
-    assert "\n\n\n" not in out
+    assert "details of segment revenue" in out
+    assert "Net income 10,593" in out
 
 
 def test_strip_xbrl_metadata_empty() -> None:

--- a/tests/test_secrag_recovery.py
+++ b/tests/test_secrag_recovery.py
@@ -16,6 +16,7 @@ from ai_buffett_zo.secrag import loader
 from ai_buffett_zo.secrag.loader import FilingMetadata
 from ai_buffett_zo.secrag.recovery import (
     RECOVERED_VIA_FILING_SUMMARY,
+    _strip_xbrl_metadata,
     is_recoverable,
     recover_pointer_sections,
 )
@@ -425,3 +426,106 @@ def test_parse_filing_summary_tolerates_missing_optional_fields() -> None:
     summary = loader._parse_filing_summary(xml)
     assert summary.reports[0].menu_category == ""
     assert summary.reports[0].position == 0
+
+
+# ---- iXBRL noise stripping (issue #43) ------------------------------------
+
+
+def test_strip_xbrl_metadata_removes_type_and_period_lines() -> None:
+    """Element balance/period-type descriptor lines are dropped."""
+    text = (
+        "Total revenue\n"
+        "62,753\n"
+        "Type: credit\n"
+        "Period Type: duration\n"
+        "Net income\n"
+        "7,500\n"
+    )
+    out = _strip_xbrl_metadata(text)
+    assert "Type: credit" not in out
+    assert "Period Type: duration" not in out
+    # Real data survives
+    assert "Total revenue" in out
+    assert "62,753" in out
+    assert "Net income" in out
+    assert "7,500" in out
+
+
+def test_strip_xbrl_metadata_removes_definition_markers() -> None:
+    text = (
+        "Cash flows from operations\n"
+        "13,500\n"
+        "X — Definition\n"
+        "No definition available.\n"
+        "Definition\n"
+        "Proceeds from new debt\n"
+        "8,391\n"
+    )
+    out = _strip_xbrl_metadata(text)
+    assert "X — Definition" not in out
+    assert "No definition available" not in out
+    # The bare "Definition" label line is gone, but data rows remain
+    assert "\nDefinition\n" not in f"\n{out}\n"
+    assert "Cash flows from operations" in out
+    assert "13,500" in out
+    assert "Proceeds from new debt" in out
+    assert "8,391" in out
+
+
+def test_strip_xbrl_metadata_removes_taxonomy_uris() -> None:
+    text = (
+        "Total assets\n"
+        "130,000\n"
+        "http://fasb.org/us-gaap/2025#Assets\n"
+        "http://www.xbrl.org/2003/role/label\n"
+        "Total liabilities\n"
+        "110,000\n"
+    )
+    out = _strip_xbrl_metadata(text)
+    assert "fasb.org" not in out
+    assert "xbrl.org" not in out
+    assert "Total assets" in out
+    assert "130,000" in out
+    assert "Total liabilities" in out
+
+
+def test_strip_xbrl_metadata_preserves_clean_text() -> None:
+    """Text with no iXBRL noise passes through unchanged (modulo trailing ws)."""
+    text = (
+        "CONSOLIDATED INCOME STATEMENT\n"
+        "Total revenue 62,753 60,530 57,351\n"
+        "Cost of goods sold (31,000)\n"
+        "Net income 7,500"
+    )
+    out = _strip_xbrl_metadata(text)
+    assert out == text.strip()
+
+
+def test_strip_xbrl_metadata_does_not_eat_data_mentioning_credit() -> None:
+    """A real line that happens to contain 'credit' mid-sentence is kept.
+
+    The filter anchors on line-start 'Type: credit', not the word 'credit'
+    anywhere — so revenue/credit-loss line items survive.
+    """
+    text = (
+        "Provision for credit losses\n"
+        "1,234\n"
+        "Credit card receivables, net\n"
+        "45,678\n"
+    )
+    out = _strip_xbrl_metadata(text)
+    assert "Provision for credit losses" in out
+    assert "Credit card receivables, net" in out
+    assert "1,234" in out
+    assert "45,678" in out
+
+
+def test_strip_xbrl_metadata_collapses_blank_runs() -> None:
+    """Removing a metadata block shouldn't leave 3+ blank lines behind."""
+    text = "Revenue\n100\nType: credit\nPeriod Type: duration\n\n\nNet income\n50"
+    out = _strip_xbrl_metadata(text)
+    assert "\n\n\n" not in out
+
+
+def test_strip_xbrl_metadata_empty() -> None:
+    assert _strip_xbrl_metadata("") == ""


### PR DESCRIPTION
Closes #43. **Draft pending canonical Zo validation against a real R-file sample** (see "Validation needed" below).

## Summary

Phase 2 recovery (PR #36) fetches SEC-rendered R-file statement tables. Those files interleave iXBRL framework metadata — element type/period descriptors, definition markers, taxonomy URIs — with the actual figures. The canonical Zo found this surfacing in search: an `evaluate IBM` run pulled `"Type: credit, Period Type: duration, X — Definition"` taxonomy pages into the **Moat** dimension's top hits instead of business narrative.

This adds `_strip_xbrl_metadata`, a conservative line filter applied to each R-file's text before concatenation.

## Design

Drops only lines matching clear metadata signatures (`_XBRL_NOISE_LINE_RE`):
- element balance type (`Type: credit/debit`)
- element period type (`Period Type: duration/instant`)
- definition markers (`X — Definition`, `No definition available`, bare `Definition`)
- taxonomy / namespace URIs (`*xbrl*`, `*fasb.org*`, `*sec.gov/CIK*`)

**Conservative by construction:** data rows (label + numeric columns) and any unrecognized line pass through untouched. Worst case it under-strips (some noise survives); it never eats real figures. The `credit`/`debit` anchors are line-start-only, so line items like `Provision for credit losses` survive.

## Validation needed before merge ⚠️

The pattern set is tuned against the canonical Zo's **described** IBM R-file format, not a real sample — I deliberately didn't finalize the regex blind (lesson from the issue #26 landmark-regex reversal). I've asked the Zo for a real R-file text excerpt; once it lands I'll confirm the patterns match the actual noise shape (inline vs. line-separated, exact wording) and adjust if needed. **Hold merge until that's confirmed.** The filter structure makes pattern changes a one-line edit.

## Files

| File | Change |
|---|---|
| `lib/ai_buffett_zo/secrag/recovery.py` | `_XBRL_NOISE_LINE_RE` + `_strip_xbrl_metadata`; applied in `_assemble_recovered_text` |
| `tests/test_secrag_recovery.py` | 7 new tests |

## Test plan

- [x] 7 new filter tests (removes type/period/definition/URI lines; preserves clean text; doesn't eat "credit losses" data lines; collapses blank runs; empty input)
- [x] 694 tests pass; ruff clean
- [ ] **Canonical Zo: confirm patterns match real IBM R-file noise format** (sample requested)
- [ ] **Canonical Zo: re-run `evaluate IBM`, confirm Moat dimension no longer surfaces "Type: credit / Period Type: duration" hits**

## No registry PR needed

`lib/` only — propagates via `git pull` on `set up Clarion`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)