### PR TITLE
fix: stop recovering Item 7 (mdna) from Statements R-files (issue #35)

### DIFF
--- a/lib/ai_buffett_zo/secrag/recovery.py
+++ b/lib/ai_buffett_zo/secrag/recovery.py
@@ -51,17 +51,30 @@ logger = logging.getLogger(__name__)
 # Labels and pointer targets where Phase 2 recovery is appropriate. Phase 1
 # (Pattern A — companion DEF 14A auto-enqueue) handles `def14a` separately.
 #
-# `parser_bug` is included after real-data validation on cis.zo.computer
-# (PR #29 review, 2026-05-22): KO's Item 8 was getting classified as
-# `parser_bug` because the curated regex trimmed the "Refer to" prefix off
-# its pointer text, leaving a body with no pointer-language tokens.
-# Excluding `parser_bug` from recovery meant KO got no fix despite having a
-# valid FilingSummary. True parser bugs (PWR business="and", MSFT TOC
-# fragments) also flow through, but FilingSummary recovery degrades
-# gracefully when no manifest exists or no Statements reports are listed —
-# so attempting recovery on parser_bug is safe and meaningfully improves
-# coverage.
-RECOVERABLE_LABELS: frozenset[str] = frozenset({"mdna", "financial_statements"})
+# **Only `financial_statements` (Item 8) is recoverable via the Statements
+# R-files.** `mdna` (Item 7) was originally included, but the Statements
+# R-files are the financial statement *tables* — they are NOT management's
+# narrative discussion. Recovering Item 7 from them (issue #35) produced text
+# identical to Item 8 on IBM (306KB of the same statements), so a query about
+# narrative MD&A returned statement tables. That's false coverage. The real
+# Item-7 MD&A narrative lives in the EX-13 exhibit, which this recovery path
+# doesn't fetch — a separate, larger capability tracked as the Phase-3 EX-13
+# follow-up. Until that exists, a pointer-only Item 7 stays a flagged pointer
+# (`is_pointer_only=True`, `recovered_via=None`) — honest about the gap rather
+# than serving statement tables mislabeled as MD&A. Item 8 still carries the
+# statements, and the Buffett lens searches across all sections, so the
+# financial-trends dimension loses nothing.
+#
+# `parser_bug` is included as a target after real-data validation on
+# cis.zo.computer (PR #29 review, 2026-05-22): KO's Item 8 was getting
+# classified as `parser_bug` because the curated regex trimmed the "Refer to"
+# prefix off its pointer text, leaving a body with no pointer-language tokens.
+# Excluding `parser_bug` meant KO got no fix despite having a valid
+# FilingSummary. True parser bugs (PWR business="and", MSFT TOC fragments)
+# also flow through, but recovery degrades gracefully when no manifest exists
+# or no Statements reports are listed — so attempting recovery on parser_bug
+# is safe and meaningfully improves coverage.
+RECOVERABLE_LABELS: frozenset[str] = frozenset({"financial_statements"})
 RECOVERABLE_TARGETS: frozenset[str] = frozenset({
     "annual_report_same_doc",
     "unknown",

--- a/tests/test_secrag_recovery.py
+++ b/tests/test_secrag_recovery.py
@@ -196,16 +196,19 @@ def _substantive_section() -> Section:
     ("label", "is_pointer", "target", "expected"),
     [
         ("financial_statements", True, "annual_report_same_doc", True),
-        ("mdna", True, "annual_report_same_doc", True),
         ("financial_statements", True, "unknown", True),
-        ("mdna", True, "unknown", True),
+        # mdna (Item 7) is NOT recoverable via Statements R-files — those are
+        # the statement tables, not management's narrative (issue #35). The
+        # real MD&A lives in EX-13 (Phase-3 follow-up). Leave Item 7 a pointer.
+        ("mdna", True, "annual_report_same_doc", False),
+        ("mdna", True, "unknown", False),
+        ("mdna", True, "parser_bug", False),
         # def14a target is Phase 1's job, not Phase 2's
         ("financial_statements", True, "def14a", False),
         # parser_bug is recoverable — see RECOVERABLE_TARGETS comment in
         # recovery.py for why (KO classified as parser_bug after Phase 0 trimmed
         # its "Refer to" prefix; FilingSummary recovery handles it gracefully)
         ("financial_statements", True, "parser_bug", True),
-        ("mdna", True, "parser_bug", True),
         # substantive section
         ("financial_statements", False, None, False),
         # other labels don't qualify even if pointer
@@ -227,6 +230,39 @@ def test_is_recoverable(label, is_pointer, target, expected) -> None:
 
 
 # ---- recover_pointer_sections — happy path ---------------------------------
+
+
+def test_recover_only_financial_statements_not_mdna(monkeypatch, tmp_path: Path) -> None:
+    """When both Item 7 (mdna) and Item 8 (financial_statements) are pointers,
+    only Item 8 is recovered from Statements R-files. Item 7 stays a flagged
+    pointer — Statements aren't MD&A narrative (issue #35).
+    """
+    _patch_recovery_http(monkeypatch)
+    mdna = _pointer_section(label="mdna", target="annual_report_same_doc")
+    fs = _pointer_section(label="financial_statements", target="annual_report_same_doc")
+    out = recover_pointer_sections(_metadata(), [mdna, fs], tmp_path)
+    by_label = {s.label: s for s in out}
+
+    # Item 8 recovered with the statements
+    assert by_label["financial_statements"].recovered_via == RECOVERED_VIA_FILING_SUMMARY
+    assert "Total revenue" in by_label["financial_statements"].text
+
+    # Item 7 NOT recovered — stays the original pointer, honestly flagged
+    assert by_label["mdna"].recovered_via is None
+    assert by_label["mdna"].is_pointer_only is True
+    assert by_label["mdna"].text == mdna.text  # unchanged pointer body
+    # And crucially: Item 7 does NOT contain the statement tables (no duplication)
+    assert "Total revenue" not in by_label["mdna"].text
+
+
+def test_recover_no_op_when_only_mdna_pointer(monkeypatch, tmp_path: Path) -> None:
+    """An mdna-only pointer triggers no recovery and no HTTP (issue #35)."""
+    captured = _patch_recovery_http(monkeypatch)
+    out = recover_pointer_sections(
+        _metadata(), [_pointer_section(label="mdna", target="annual_report_same_doc")], tmp_path
+    )
+    assert out[0].recovered_via is None
+    assert captured["urls"] == []
 
 
 def test_recover_replaces_pointer_with_r_file_content(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #35.

## Summary

Phase 2 recovery treated both Item 7 (`mdna`) and Item 8 (`financial_statements`) as recoverable from the FilingSummary Statements R-files. But those R-files are the financial statement **tables** — not management's narrative. The canonical Zo's validation found IBM's `mdna` recovered to text **identical** to its `financial_statements` (both 306KB of the same statements), so a query about narrative MD&A returned statement tables. False coverage.

## Fix

Remove `"mdna"` from `RECOVERABLE_LABELS` — only `financial_statements` recovers from Statements R-files. A pointer-only Item 7 now stays a **flagged pointer** (`is_pointer_only=True`, `recovered_via=None`) — honest about the gap rather than serving tables mislabeled as MD&A.

**Nothing is lost:** Item 8 still carries the statements, and the Buffett lens searches across all sections, so the financial-trends dimension is unaffected. This removes the real harms of the duplication (wasted LLM/storage on a second copy; statement tables polluting MD&A search) without pretending to have content we don't.

## Why not pull Notes for Item 7 instead?

Considered and rejected. `MenuCategory="Notes"` R-files are accounting-policy notes, not the MD&A narrative — so that would swap one wrong content for another while *looking* fixed. The actual MD&A lives in the EX-13 exhibit, which this recovery path doesn't fetch. That real fix is a larger, separate capability — filed as **#46 (Phase 3: recover Item 7 MD&A from EX-13)**.

## Files

| File | Change |
|---|---|
| `lib/ai_buffett_zo/secrag/recovery.py` | `RECOVERABLE_LABELS` → `{"financial_statements"}`; docstring explains why mdna is excluded + the EX-13 follow-up |
| `tests/test_secrag_recovery.py` | `is_recoverable` cases updated (mdna → False); 2 new tests (dual-pointer → only Item 8 recovered; mdna-only → no recovery, no HTTP) |

## Test plan

- [x] 689 tests pass; ruff clean
- [x] New test: both Item 7 + Item 8 pointers → only Item 8 recovered, Item 7 stays a pointer with **no** statement-table duplication
- [x] New test: mdna-only pointer → zero HTTP, no recovery
- [ ] Post-merge canonical Zo: re-index IBM, confirm `mdna` section is a short pointer (not 306KB duplicate) and `financial_statements` still recovers fully

## No registry PR needed

`lib/` only — propagates via `git pull` on `set up Clarion`.

## Mergeable now

Unlike #45 (#43 iXBRL filter, held for a real R-file sample), this is deterministic — no external data needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)