### PR TITLE
perf: parallelize tree-build LLM summaries (#48)

### DIFF
--- a/lib/ai_buffett_zo/indexer/main.py
+++ b/lib/ai_buffett_zo/indexer/main.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import sys
 import time
 from collections.abc import Callable
@@ -55,9 +56,26 @@ from ai_buffett_zo.secrag import (
     should_full_index,
 )
 from ai_buffett_zo.secrag.recovery import recover_pointer_sections
+from ai_buffett_zo.secrag.tree import DEFAULT_TREE_CONCURRENCY
 
 DEFAULT_POLL_INTERVAL = 5.0
 LOG_FILENAME = ".indexer.log"
+CONCURRENCY_ENV = "CLARION_INDEX_CONCURRENCY"
+
+
+def _index_concurrency() -> int:
+    """Tree-build parallelism (issue #48), from CLARION_INDEX_CONCURRENCY.
+
+    Defaults to DEFAULT_TREE_CONCURRENCY. A malformed or non-positive value
+    falls back to 1 (serial) — never crash the service over a bad env var.
+    """
+    raw = os.environ.get(CONCURRENCY_ENV)
+    if not raw:
+        return DEFAULT_TREE_CONCURRENCY
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return 1
 
 
 def setup_logging(sec_root: Path, *, verbose: bool = False) -> logging.Logger:
@@ -170,7 +188,9 @@ def process_one(
         total_tokens = sum(len(s.text) for s in sections) // 4
         with timing.stage("tree-build"):
             if should_full_index(metadata.form, total_tokens):
-                builder = TreeBuilder(client, model=model)
+                builder = TreeBuilder(
+                    client, model=model, max_concurrency=_index_concurrency()
+                )
                 tree = builder.build(metadata, sections)
             else:
                 tree = build_raw_tree(metadata, sections)

--- a/lib/ai_buffett_zo/secrag/tree.py
+++ b/lib/ai_buffett_zo/secrag/tree.py
@@ -15,9 +15,12 @@ chunk sizing; the actual model context is far larger than any chunk we produce.
 from __future__ import annotations
 
 import time
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import Any
+from functools import partial
+from typing import Any, TypeVar
 
 from ai_buffett_zo.llm import (
     DEFAULT_MODEL_INDEX,
@@ -29,6 +32,18 @@ from ai_buffett_zo.secrag.sections import Section
 
 DEFAULT_MAX_CHUNK_TOKENS = 4000  # well under any model's context; ~16k chars
 RAW_INDEX_TOKEN_LIMIT = 15_000   # safety net: a "raw" filing this long gets full indexing
+
+# Bounded parallelism for LLM summary calls (issue #48). tree-build is ~97% of
+# indexing time, and it's dominated by serial /zo/ask calls — one per section,
+# plus one per chunk for long sections. The calls are independent, so running a
+# handful concurrently cuts per-filing wall-clock several-fold. Kept modest to
+# stay well under Zo API rate limits; the indexer still processes one filing at
+# a time, so total in-flight calls are bounded by this number. Override per
+# deployment via CLARION_INDEX_CONCURRENCY (read in indexer/main.py); set to 1
+# to fall back to fully serial behavior.
+DEFAULT_TREE_CONCURRENCY = 4
+
+_T = TypeVar("_T")
 
 
 @dataclass
@@ -145,13 +160,96 @@ class TreeBuilder:
         *,
         model: str = DEFAULT_MODEL_INDEX,
         max_chunk_tokens: int = DEFAULT_MAX_CHUNK_TOKENS,
+        max_concurrency: int = DEFAULT_TREE_CONCURRENCY,
     ) -> None:
         self.client = client
         self.model = model
         self.max_chunk_tokens = max_chunk_tokens
+        self.max_concurrency = max(1, max_concurrency)
 
     def build(self, metadata: FilingMetadata, sections: list[Section]) -> FilingTree:
-        section_nodes = [self._build_section(metadata, s) for s in sections]
+        """Build a FilingTree, summarizing leaf calls with bounded parallelism.
+
+        The work is two waves of independent LLM calls (issue #48):
+
+        - **Phase 1 — leaves:** one summary per whole short section, plus one
+          per chunk for every long section. All independent → run concurrently.
+        - **Phase 2 — synthesis:** one call per long section, folding its chunk
+          summaries into a section summary. Independent across sections → also
+          concurrent, but depends on Phase 1 for that section's chunks.
+
+        Output is identical to a serial build — same prompts, same model, same
+        assembly order. Only the wall-clock differs. With ``max_concurrency=1``
+        this degrades to fully serial execution.
+        """
+        # Plan: for each section, None == fits whole; else the list of chunk texts.
+        plans: list[tuple[Section, list[str] | None]] = [
+            (s, self._chunks_for(s)) for s in sections
+        ]
+
+        # Phase 1 — every leaf summary, in original (section, chunk) order.
+        leaf_keys: list[tuple[int, int]] = []   # (section_idx, chunk_idx); -1 == whole
+        leaf_fns: list[Callable[[], dict[str, Any]]] = []
+        for si, (s, chunks_text) in enumerate(plans):
+            if chunks_text is None:
+                leaf_keys.append((si, -1))
+                leaf_fns.append(partial(self._summarize_text, metadata, s.label, s.text))
+            else:
+                for ci, ct in enumerate(chunks_text):
+                    leaf_keys.append((si, ci))
+                    leaf_fns.append(
+                        partial(self._summarize_text, metadata, f"{s.label}/chunk{ci}", ct)
+                    )
+        leaf_data = dict(zip(leaf_keys, self._map_parallel(leaf_fns), strict=True))
+
+        # Reconstruct chunk nodes per section (in chunk order) for synthesis.
+        chunk_nodes_by_section: dict[int, list[ChunkNode]] = {}
+        for si, (_s, chunks_text) in enumerate(plans):
+            if chunks_text is None:
+                continue
+            chunk_nodes_by_section[si] = [
+                ChunkNode(
+                    chunk_index=ci,
+                    text=ct,
+                    summary=leaf_data[(si, ci)].get("one_sentence_summary", ""),
+                    summary_data=leaf_data[(si, ci)],
+                )
+                for ci, ct in enumerate(chunks_text)
+            ]
+
+        # Phase 2 — synthesis per chunked section.
+        synth_idx = list(chunk_nodes_by_section.keys())
+        synth_fns = [
+            partial(
+                self._synthesize_section, metadata, plans[si][0].label,
+                chunk_nodes_by_section[si],
+            )
+            for si in synth_idx
+        ]
+        synth_data = dict(zip(synth_idx, self._map_parallel(synth_fns), strict=True))
+
+        # Assemble section nodes in original order.
+        section_nodes: list[SectionNode] = []
+        for si, (s, chunks_text) in enumerate(plans):
+            if chunks_text is None:
+                data = leaf_data[(si, -1)]
+                chunks: list[ChunkNode] = []
+            else:
+                data = synth_data[si]
+                chunks = chunk_nodes_by_section[si]
+            section_nodes.append(
+                SectionNode(
+                    label=s.label,
+                    title=s.title,
+                    text=s.text,
+                    summary=data.get("one_sentence_summary", ""),
+                    summary_data=data,
+                    chunks=chunks,
+                    is_pointer_only=s.is_pointer_only,
+                    pointer_target=s.pointer_target,
+                    recovered_via=s.recovered_via,
+                )
+            )
         return FilingTree(
             metadata=metadata,
             sections=section_nodes,
@@ -159,48 +257,25 @@ class TreeBuilder:
             indexer_model=self.model,
         )
 
-    def _build_section(
-        self, metadata: FilingMetadata, section: Section
-    ) -> SectionNode:
+    def _chunks_for(self, section: Section) -> list[str] | None:
+        """Chunk plan for a section: None if it fits whole, else the chunk texts."""
         if _estimate_tokens(section.text) <= self.max_chunk_tokens:
-            data = self._summarize_text(metadata, section.label, section.text)
-            return SectionNode(
-                label=section.label,
-                title=section.title,
-                text=section.text,
-                summary=data.get("one_sentence_summary", ""),
-                summary_data=data,
-                chunks=[],
-                is_pointer_only=section.is_pointer_only,
-                pointer_target=section.pointer_target,
-                recovered_via=section.recovered_via,
-            )
+            return None
+        return _chunk_text(section.text, target_tokens=self.max_chunk_tokens)
 
-        chunks_text = _chunk_text(section.text, target_tokens=self.max_chunk_tokens)
-        chunk_nodes: list[ChunkNode] = []
-        for i, ct in enumerate(chunks_text):
-            data = self._summarize_text(metadata, f"{section.label}/chunk{i}", ct)
-            chunk_nodes.append(
-                ChunkNode(
-                    chunk_index=i,
-                    text=ct,
-                    summary=data.get("one_sentence_summary", ""),
-                    summary_data=data,
-                )
-            )
+    def _map_parallel(self, fns: list[Callable[[], _T]]) -> list[_T]:
+        """Run zero-arg callables, returning results in input order.
 
-        synth_data = self._synthesize_section(metadata, section.label, chunk_nodes)
-        return SectionNode(
-            label=section.label,
-            title=section.title,
-            text=section.text,
-            summary=synth_data.get("one_sentence_summary", ""),
-            summary_data=synth_data,
-            chunks=chunk_nodes,
-            is_pointer_only=section.is_pointer_only,
-            pointer_target=section.pointer_target,
-            recovered_via=section.recovered_via,
-        )
+        Bounded by ``max_concurrency``. Falls back to a plain serial loop when
+        concurrency is 1 or there's at most one task — avoids spinning up a
+        thread pool for the common short-filing case. ``ThreadPoolExecutor.map``
+        preserves input order and only keeps ``max_workers`` calls in flight.
+        """
+        if self.max_concurrency <= 1 or len(fns) <= 1:
+            return [fn() for fn in fns]
+        workers = min(self.max_concurrency, len(fns))
+        with ThreadPoolExecutor(max_workers=workers) as ex:
+            return list(ex.map(lambda fn: fn(), fns))
 
     def _summarize_text(
         self, metadata: FilingMetadata, label: str, text: str

--- a/tests/test_indexer_main.py
+++ b/tests/test_indexer_main.py
@@ -100,9 +100,12 @@ def _patch_pipeline(
         return secs
 
     class FakeBuilder:
-        def __init__(self, client: Any, *, model: str = "x") -> None:
+        def __init__(
+            self, client: Any, *, model: str = "x", max_concurrency: int = 1
+        ) -> None:
             self.client = client
             self.model = model
+            self.max_concurrency = max_concurrency
 
         def build(self, metadata: FilingMetadata, sections: list[Section]) -> FilingTree:
             captured["built"].append((metadata, sections))
@@ -376,3 +379,25 @@ def test_run_loop_processes_pending_then_sleeps(
     # Both processed, queue is empty (in pending dir)
     assert list_pending(queue_root) == []
     assert sleeps == [7.5]
+
+
+# ---- tree-build concurrency knob (issue #48) --------------------------------
+
+
+def test_index_concurrency_defaults_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(main_mod.CONCURRENCY_ENV, raising=False)
+    assert main_mod._index_concurrency() == main_mod.DEFAULT_TREE_CONCURRENCY
+
+
+def test_index_concurrency_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(main_mod.CONCURRENCY_ENV, "8")
+    assert main_mod._index_concurrency() == 8
+
+
+def test_index_concurrency_bad_value_falls_back_to_serial(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(main_mod.CONCURRENCY_ENV, "garbage")
+    assert main_mod._index_concurrency() == 1
+    monkeypatch.setenv(main_mod.CONCURRENCY_ENV, "0")
+    assert main_mod._index_concurrency() == 1

--- a/tests/test_indexer_routing.py
+++ b/tests/test_indexer_routing.py
@@ -90,9 +90,12 @@ def _patch(
         return sections
 
     class FakeBuilder:
-        def __init__(self, client: Any, *, model: str = "x") -> None:
+        def __init__(
+            self, client: Any, *, model: str = "x", max_concurrency: int = 1
+        ) -> None:
             self.client = client
             self.model = model
+            self.max_concurrency = max_concurrency
 
         def build(self, m: FilingMetadata, _sections: list[Section]) -> FilingTree:
             captured["tree_builder_invoked"] = True

--- a/tests/test_secrag_tree.py
+++ b/tests/test_secrag_tree.py
@@ -6,6 +6,7 @@ shape, prompt content, and chunking decisions.
 
 from __future__ import annotations
 
+import threading
 from datetime import date
 from typing import Any
 
@@ -150,3 +151,80 @@ def test_real_zo_client_type_compatible() -> None:
     """Sanity: TreeBuilder accepts a real ZoClient by type, even if we never call it."""
     builder = TreeBuilder(ZoClient(token="zo_sk_test"))
     assert builder.client is not None
+
+
+# ---- bounded parallelism (issue #48) ----------------------------------------
+
+
+def _sections(n: int) -> list[Section]:
+    return [
+        Section(label=f"s{i}", title=f"Item {i}", text=f"short text {i}",
+                char_start=0, char_end=12)
+        for i in range(n)
+    ]
+
+
+def test_max_concurrency_clamped_to_at_least_one() -> None:
+    assert TreeBuilder(_MockClient({}), max_concurrency=0).max_concurrency == 1  # type: ignore[arg-type]
+    assert TreeBuilder(_MockClient({}), max_concurrency=-5).max_concurrency == 1  # type: ignore[arg-type]
+
+
+def test_build_runs_leaf_calls_concurrently() -> None:
+    """N independent leaf summaries must run in parallel.
+
+    A barrier of size N only releases when N calls are simultaneously in
+    flight. Under serial execution the first wait() blocks alone and trips the
+    5s timeout (BrokenBarrierError → test failure). Passing proves real
+    concurrency, not just correct output.
+    """
+    n = 4
+    barrier = threading.Barrier(n, timeout=5)
+    reached = 0
+    lock = threading.Lock()
+
+    class _BarrierClient:
+        def ask(self, input: str, **kwargs: Any) -> AskResult:
+            nonlocal reached
+            barrier.wait()
+            with lock:
+                reached += 1
+            return AskResult(ok=True, data=_summary("x"), raw={}, elapsed_s=0.0,
+                             model="test")
+
+    builder = TreeBuilder(_BarrierClient(), max_concurrency=n)  # type: ignore[arg-type]
+    tree = builder.build(_meta(), _sections(n))
+
+    assert reached == n
+    # Order preserved despite concurrent completion.
+    assert [s.label for s in tree.sections] == [f"s{i}" for i in range(n)]
+
+
+def test_parallel_output_identical_to_serial() -> None:
+    """max_concurrency=4 must produce the same tree as max_concurrency=1."""
+    para = ("a " * 2500).strip()                 # ~5000 chars
+    long_text = "\n\n".join([para] * 4)          # forces chunking + synthesis
+    sections = [
+        Section(label="business", title="Item 1", text="short business",
+                char_start=0, char_end=14),
+        Section(label="mdna", title="Item 7", text=long_text,
+                char_start=0, char_end=len(long_text)),
+        Section(label="risk_factors", title="Item 1A", text="short risk",
+                char_start=0, char_end=10),
+    ]
+
+    def make(concurrency: int) -> FilingTree:
+        return TreeBuilder(
+            _MockClient({}), max_chunk_tokens=2000, max_concurrency=concurrency,  # type: ignore[arg-type]
+        ).build(_meta(), sections)
+
+    serial = make(1)
+    parallel = make(4)
+
+    assert [s.label for s in serial.sections] == [s.label for s in parallel.sections]
+    for ss, ps in zip(serial.sections, parallel.sections):
+        assert ss.summary == ps.summary
+        assert [c.chunk_index for c in ps.chunks] == list(range(len(ps.chunks)))
+        # Chunk texts assembled in the same order regardless of completion order.
+        assert [c.text for c in ss.chunks] == [c.text for c in ps.chunks]
+    # The long mdna section actually chunked (otherwise this proves nothing).
+    assert len(parallel.sections[1].chunks) >= 2


### PR DESCRIPTION
## Summary

`tree-build` is **~97-98% of SEC indexing time** (PR #44 timing: NVDA 10-K `total=70.1s tree-build=68.6s`). It was fully serial — one `/zo/ask` summary call per section, plus one per chunk for long sections, plus one synthesis call per chunked section, all awaited in sequence. Those calls are independent, so this runs them under a bounded thread pool.

`TreeBuilder.build` now works in two concurrent waves:
1. **Leaves** — every whole-short-section summary + every chunk summary across all sections, fired together (bounded).
2. **Synthesis** — one fold per chunked section, fired together; depends on wave 1 for that section's chunks.

Nodes are then assembled in original section/chunk order. **Output is identical to the serial path** — same prompts, same model, same ordering. Only wall-clock changes. At default concurrency 4, a ~68s tree-build should drop to roughly ~17-20s.

## Safety
- **Thread-safety:** `ZoClient.ask` uses stdlib `urllib` with a fresh request per call and no shared mutable state — safe to call from multiple threads; `urlopen` blocks (releases the GIL) so threads give real I/O concurrency.
- **Rate limits:** concurrency defaults to **4** and is overridable via `CLARION_INDEX_CONCURRENCY` (set `1` for fully serial). The indexer still processes **one filing at a time**, so total in-flight `/zo/ask` calls are bounded by this knob.
- **Degradation:** `max_concurrency=1` (or ≤1 task) skips the pool entirely and runs serially — identical to old behavior.

## Tests (+6, 732 total green)
- **Proof of real parallelism:** a `threading.Barrier(N)` that only releases when N leaf calls are simultaneously in flight — serial execution would trip the 5s timeout. 
- **Output-identical:** a multi-section + chunked filing built at concurrency 1 vs 4 yields the same summaries, chunk order, and chunk text.
- `max_concurrency` clamp (≤0 → 1); `_index_concurrency()` env parsing (default / value / bad-value → serial).
- Existing tree tests pass unchanged (count-based assertions hold under reordering).

## Validation plan (canonical Zo)
Force-reindex NVDA/IBM/KO and compare the PR #44 `timing … tree-build=Ns` log line against the baseline in #48; spot-check that the Buffett-lens eval still surfaces the right sections (no retrieval-quality regression).

Closes #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)