### PR TITLE
fix: anchor curated sections on body header, not TOC or cross-references (#51)

### DIFF
--- a/lib/ai_buffett_zo/secrag/sections.py
+++ b/lib/ai_buffett_zo/secrag/sections.py
@@ -86,6 +86,78 @@ ANY_ITEM_HEADER = re.compile(
     re.IGNORECASE,
 )
 
+# A real section header stands alone on its line — optionally after a structural
+# "PART II" label. Text on the line *before* the item header means the match is
+# an in-body cross-reference ("…as described in Item 1A. Risk Factors for…",
+# "see Item 7, Management's Discussion…"), never the section itself. Selecting
+# those (the old last-match-wins rule did, because cross-references appear later
+# in the doc than the real header) is what made risk_factors / mdna anchor into
+# MD&A for NVDA, GOOGL, KO, WMT, XOM, TTD, JPM (issue #51). This pattern matches
+# an acceptable line-prefix: empty, or just a "PART <roman>" label.
+_HEADER_LINE_PREFIX_RE = re.compile(
+    r"^(part\s+[ivxlcdm]+\b[\.\s\-:–—]*)?$",
+    re.IGNORECASE,
+)
+
+
+def _is_inline_cross_reference(text: str, m: re.Match[str]) -> bool:
+    """True when an item-header match sits inside running prose, not on its own line.
+
+    Looks at the text from the start of the match's line up to the match. If
+    that prefix is empty (or just a ``PART II`` label) the match begins the line
+    → it's a real header. Any other prose before it → an in-body cross-reference.
+    """
+    line_start = text.rfind("\n", 0, m.start()) + 1
+    before = text[line_start:m.start()].strip()
+    if not before:
+        return False
+    return _HEADER_LINE_PREFIX_RE.match(before) is None
+
+
+# The body under a *real* curated section header is long, substantive prose.
+# Two impostors share the same header text and must be rejected when choosing
+# which occurrence is the section (issue #51):
+#   - TOC entry: body is a page number then the next item — e.g. "16 Item 1B".
+#   - cross-reference that wrapped to a line start: body is a quote-close or
+#     sentence fragment — e.g. '" of this Annual Report', ': Operational…'.
+_CROSS_REF_BODY_STARTS = ('"', "“", "”", "’", "'", ":", ";", ")", "]", "}")
+_MIN_SECTION_BODY_CHARS = 120
+
+
+def _is_section_body_start(body: str) -> bool:
+    """Does ``body`` (text right after an item header) look like a real section?
+
+    Rejects the two impostor shapes above: too-short bodies (TOC page-refs end
+    at the next item header within a few chars), bodies starting with a digit
+    (TOC page number), and bodies starting with a quote/colon (cross-reference
+    tail). Everything else is treated as substantive section prose. A leading
+    "." is *not* rejected — real headers render as "Risk Factors.\\n<prose>".
+    """
+    s = body.strip()
+    if len(s) < _MIN_SECTION_BODY_CHARS:
+        return False
+    first = s[0]
+    return not (first.isdigit() or first in _CROSS_REF_BODY_STARTS)
+
+
+def _select_header_match(text: str, matches: list[re.Match[str]]) -> re.Match[str]:
+    """Pick the occurrence of an item header that is the real section header.
+
+    Walks matches in document order and returns the first that is (a) a
+    standalone header line, not an in-body cross-reference, and (b) immediately
+    followed by a substantive body (not a TOC page-ref or a quoted
+    cross-reference tail). Falls back to the last match when none qualifies, so
+    a section is never silently dropped — matches the prior behavior on filings
+    whose real body header isn't separately matchable (issue #51).
+    """
+    for m in matches:
+        if _is_inline_cross_reference(text, m):
+            continue
+        body = text[m.end():_find_section_end(text, after=m.end())]
+        if _is_section_body_start(body):
+            return m
+    return matches[-1]
+
 # Anchor used by the TOC-aware retry path (issue #32). The body of a 10-K
 # always starts with "PART I" right after the table of contents. When the
 # first-pass curated regex matches only TOC entries, we re-search starting
@@ -358,21 +430,28 @@ def extract_sections_from_text(text: str) -> list[Section]:
 def _curated_pass(text: str, *, search_start: int) -> list[Section]:
     """One pass of the curated regex matching, starting at ``search_start``.
 
-    Preserves the original "last match per label wins" behavior so that
-    when a body heading appears multiple times in the doc (e.g., TOC +
-    body), we pick the latest one — which is typically the body. The
-    ``search_start`` parameter lets the caller skip past a known-TOC
-    region entirely for the retry pass.
-    """
-    last_match: dict[str, re.Match[str]] = {}
-    for label, pattern in CURATED_SECTIONS.items():
-        for m in pattern.finditer(text, pos=search_start):
-            last_match[label] = m
+    Selection per label (issue #51): an item header like "Item 1A. Risk
+    Factors" appears several times in a 10-K — in the table of contents, as the
+    real body header, and in in-body cross-references ("see Item 1A. Risk
+    Factors for…"). The old rule kept the *last* match, which overshot onto a
+    cross-reference deep in MD&A (NVDA, GOOGL, KO, …). Instead we pick the
+    *first* occurrence that is a real section header: a standalone line (not
+    embedded in prose) whose body is substantive (not a TOC page-ref, not a
+    quoted cross-reference tail). See ``_select_header_match``.
 
-    if not last_match:
+    The ``search_start`` parameter lets the caller skip past a known-TOC region
+    entirely for the retry pass.
+    """
+    chosen: dict[str, re.Match[str]] = {}
+    for label, pattern in CURATED_SECTIONS.items():
+        matches = list(pattern.finditer(text, pos=search_start))
+        if matches:
+            chosen[label] = _select_header_match(text, matches)
+
+    if not chosen:
         return []
 
-    ordered = sorted(last_match.items(), key=lambda kv: kv[1].start())
+    ordered = sorted(chosen.items(), key=lambda kv: kv[1].start())
 
     sections: list[Section] = []
     for i, (label, m) in enumerate(ordered):

--- a/tests/test_secrag_sections.py
+++ b/tests/test_secrag_sections.py
@@ -11,9 +11,13 @@ from ai_buffett_zo.secrag import (
 )
 from ai_buffett_zo.secrag.sections import (
     _detect_pointer,
+    _is_inline_cross_reference,
+    _is_section_body_start,
     _is_toc_shaped,
+    _select_header_match,
     extract_sections_for_form,
 )
+from ai_buffett_zo.secrag.sections import CURATED_SECTIONS
 
 
 SAMPLE_10K_HTML = """
@@ -423,3 +427,107 @@ def test_pointer_detection_propagates_to_extracted_section() -> None:
     assert by_label["business"].pointer_target is None
     assert by_label["risk_factors"].is_pointer_only is False
     assert by_label["risk_factors"].pointer_target is None
+
+
+# ---- cross-reference / TOC anchor selection (issue #51) ---------------------
+
+# A synthetic 10-K with the three impostor occurrences of "Item 1A. Risk
+# Factors": the TOC entry (page number), the real body header (substantive
+# prose), and an in-body MD&A cross-reference. The extractor must anchor on the
+# body header — not the TOC (old TOC failure) and not the cross-reference (the
+# old last-match-wins overshoot that put MD&A text in risk_factors).
+_DOC_WITH_CROSS_REFS = """Table of Contents
+
+Item 1. Business 3
+Item 1A. Risk Factors 24
+Item 1B. Unresolved Staff Comments 40
+Item 7. Management's Discussion and Analysis 55
+Item 8. Financial Statements 80
+
+PART I
+
+Item 1. Business
+
+We design and manufacture widgets and sell them to a global base of customers
+across many industries, competing on quality, scale, and an integrated software
+ecosystem that we have built over many years.
+
+Item 1A. Risk Factors
+
+The following risk factors could materially and adversely affect our business,
+financial condition, and results of operations. You should carefully consider
+each of them together with the other information in this report before investing.
+
+Item 1B. Unresolved Staff Comments
+
+None.
+
+PART II
+
+Item 7. Management's Discussion and Analysis of Financial Condition and Results of Operations
+
+Our revenue grew during the period. For additional detail on competitive and
+regulatory pressures, see Item 1A. Risk Factors for additional information
+regarding our investments and operations during fiscal year 2026 and beyond.
+
+Item 8. Financial Statements
+
+The consolidated financial statements are set forth on the pages that follow and
+include the balance sheet, income statement, and statement of cash flows for each
+of the periods presented in this annual report.
+"""
+
+
+def test_risk_factors_anchors_on_body_header_not_cross_reference() -> None:
+    sections = extract_sections_from_text(_DOC_WITH_CROSS_REFS)
+    by = {s.label: s for s in sections}
+    rf = by["risk_factors"]
+    # Body header wins: starts with the real risk-factors prose...
+    assert rf.text.startswith("The following risk factors could materially")
+    # ...not the MD&A cross-reference text that the old last-match rule grabbed.
+    assert "Our revenue grew" not in rf.text
+    assert "for additional information regarding our investments" not in rf.text
+
+
+def test_mdna_anchors_past_toc_to_body_header() -> None:
+    sections = extract_sections_from_text(_DOC_WITH_CROSS_REFS)
+    by = {s.label: s for s in sections}
+    assert by["mdna"].text.startswith("of Financial Condition and Results of Operations")
+    assert "Our revenue grew during the period" in by["mdna"].text
+
+
+def test_is_inline_cross_reference_detects_prose_prefix() -> None:
+    text = "...see Item 1A. Risk Factors for more.\nItem 1A. Risk Factors\nbody"
+    pat = CURATED_SECTIONS["risk_factors"]
+    matches = list(pat.finditer(text))
+    assert len(matches) == 2
+    assert _is_inline_cross_reference(text, matches[0]) is True   # embedded in prose
+    assert _is_inline_cross_reference(text, matches[1]) is False  # begins its line
+
+
+def test_is_inline_cross_reference_allows_part_prefix() -> None:
+    text = "PART I Item 1A. Risk Factors\nbody"
+    m = CURATED_SECTIONS["risk_factors"].search(text)
+    assert m is not None
+    assert _is_inline_cross_reference(text, m) is False
+
+
+def test_is_section_body_start_rejects_toc_and_cross_ref_shapes() -> None:
+    assert _is_section_body_start("24\nItem 1B. Unresolved Staff Comments") is False  # TOC page#
+    assert _is_section_body_start('" of this Annual Report on Form 10-K. ' * 5) is False  # quote tail
+    assert _is_section_body_start(": Operational and Other Factors -- Cybersecurity") is False
+    assert _is_section_body_start("x") is False  # too short
+    assert _is_section_body_start(
+        "The following risk factors could materially and adversely affect our "
+        "business and financial condition and results of operations going forward."
+    ) is True
+
+
+def test_select_header_match_falls_back_to_last_when_no_body_header() -> None:
+    # Only a TOC-style occurrence exists (mirrors MSFT/SYF: body header not
+    # separately matchable). Selection must not crash — it falls back to the
+    # last match rather than dropping the section.
+    text = "Item 1A. Risk Factors 16\nItem 1B. Unresolved Staff Comments 30\n"
+    matches = list(CURATED_SECTIONS["risk_factors"].finditer(text))
+    assert len(matches) == 1
+    assert _select_header_match(text, matches) is matches[-1]


### PR DESCRIPTION
## Summary

Fixes the systemic section mis-anchoring from #51. `_curated_pass` kept the **last** regex match per label. An item header like "Item 1A. Risk Factors" appears three ways in a 10-K — the **TOC entry**, the **real body header**, and in-body **cross-references** ("…see Item 1A. Risk Factors for additional information…"). Cross-references appear later in the document than the real header, so last-match-wins overshot onto a cross-reference — dropping MD&A text into `risk_factors`.

## Root cause (validated against live SEC data)

A 17-ticker probe (fetch → extract, no LLM — reproducible locally) found **~half the sample broken**, in two distinct modes:
- **Cross-reference overshoot** (NVDA, GOOGL, XOM, WMT, KO, TTD, JPM): multiple matches; last-match landed on a cross-reference, often deep in MD&A. ← **this PR**
- **Body header uncaptured** (MSFT, SYF): only the *TOC* occurrence of "Item 1A. Risk Factors" is matchable; the body header isn't. ← separate issue (filed).

## Fix

Pick the **first** occurrence that is a real section header:
1. a **standalone line** — not embedded in running prose (modulo a `PART II` label); and
2. immediately followed by a **substantive body** — not a TOC page-ref (`"24 Item 1B…"`) and not a quoted cross-reference tail (`'" of this report'`, `": Operational…"`).

Falls back to the last match when none qualifies, so a section is never silently dropped (preserves prior behavior on MSFT/SYF-style filings). Selection is **uniform across all four curated sections** (business / risk_factors / mdna / financial_statements), so mdna benefits from the same correction.

## Result

| | Before | After |
|---|---|---|
| Correctly anchored (17-ticker probe) | 8/17 | **15/17** |
| Regressions on the 8 that worked | — | **none** |

Examples now fixed: NVDA `risk_factors` 5,526 chars (MD&A capex text) → 125,374 chars ("The following risk factors should be considered…"); XOM/WMT/TTD/KO/GOOGL/JPM likewise now start at the real Item 1A opener. The remaining MSFT/SYF are the body-header-uncaptured mode, tracked separately.

## Tests (+6)
Synthetic 10-K with all three impostor occurrences: asserts `risk_factors` anchors on the body header (not the TOC, not the MD&A cross-reference) and that mdna anchors past the TOC. Unit tests for `_is_inline_cross_reference` (prose prefix vs. PART prefix), `_is_section_body_start` (TOC/quote/short shapes rejected), and the `_select_header_match` fallback. Full suite: 732 green.

## Validation plan (canonical Zo)
Re-index the affected tickers and confirm the Risk dimension of `clarion-single-stock-eval` populates with real risk-factor snippets (it was empty/garbage for NVDA before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)