### PR TITLE
feat: re-extract on upgrade so extraction fixes reach the existing corpus (#57)

### DIFF
--- a/lib/ai_buffett_zo/indexer/__init__.py
+++ b/lib/ai_buffett_zo/indexer/__init__.py
@@ -13,6 +13,7 @@ from ai_buffett_zo.indexer.queue import (
 from ai_buffett_zo.indexer.runtime import (
     IndexerHealth,
     indexer_health,
+    is_tree_stale,
     write_runtime_marker,
 )
 from ai_buffett_zo.indexer.status import (
@@ -37,6 +38,7 @@ __all__ = [
     "default_priority",
     "enqueue",
     "indexer_health",
+    "is_tree_stale",
     "list_pending",
     "load_status",
     "mark_done",

--- a/lib/ai_buffett_zo/indexer/main.py
+++ b/lib/ai_buffett_zo/indexer/main.py
@@ -19,6 +19,7 @@ CLI:
 from __future__ import annotations
 
 import argparse
+import dataclasses
 import json
 import logging
 import os
@@ -34,7 +35,7 @@ from ai_buffett_zo.indexer.queue import (
     mark_done,
     mark_failed,
 )
-from ai_buffett_zo.indexer.runtime import write_runtime_marker
+from ai_buffett_zo.indexer.runtime import is_tree_stale, write_runtime_marker
 from ai_buffett_zo.indexer.status import (
     FilingStatus,
     load_status,
@@ -52,6 +53,7 @@ from ai_buffett_zo.secrag import (
     fetch_filing,
     fetch_filing_by_accession,
     is_indexed,
+    load_tree,
     save_raw,
     save_tree,
     should_full_index,
@@ -103,8 +105,14 @@ def process_one(
     client: ZoClient,
     default_model: str,
     logger: logging.Logger,
+    indexer_commit: str | None = None,
 ) -> None:
-    """Process a single queued request end-to-end. Updates queue + status."""
+    """Process a single queued request end-to-end. Updates queue + status.
+
+    ``indexer_commit`` is the running code's git commit (issue #57); it's
+    stamped on the produced tree and used to decide whether an already-indexed
+    filing is stale and should be re-extracted.
+    """
     claimed = claim(request_id, root=queue_root)
     if claimed is None:
         return
@@ -120,6 +128,7 @@ def process_one(
     form = req.get("form", "10-K")
     model = req.get("model") or default_model
     accession = req.get("accession")
+    force = bool(req.get("force", False))
 
     logger.info(
         "processing %s (%s/%s%s) with %s",
@@ -147,11 +156,27 @@ def process_one(
                 metadata, html = fetch_filing(ticker, form=form)
 
         if is_indexed(sec_root, ticker, metadata.accession):
-            logger.info("already indexed: %s %s", ticker, metadata.accession)
-            status.update_request(form=form, state="completed")
-            save_status(sec_root, status)
-            mark_done(request_id, root=queue_root)
-            return
+            # Already on disk. Re-extract only when forced or when the stored
+            # tree was built by older code (issue #57) — otherwise skip, so a
+            # routine re-index stays cheap. A tree that fails to load is treated
+            # as stale and rebuilt.
+            reextract = force
+            if not reextract:
+                try:
+                    existing = load_tree(sec_root, ticker, metadata.accession)
+                    reextract = is_tree_stale(existing.indexer_commit, indexer_commit)
+                except Exception:  # noqa: BLE001 — unreadable tree → rebuild it
+                    reextract = True
+            if not reextract:
+                logger.info("already indexed (current): %s %s", ticker, metadata.accession)
+                status.update_request(form=form, state="completed")
+                save_status(sec_root, status)
+                mark_done(request_id, root=queue_root)
+                return
+            logger.info(
+                "re-extracting %s %s (force=%s, now=%s)",
+                ticker, metadata.accession, force, indexer_commit,
+            )
 
         save_raw(sec_root, metadata, html)
         # Form-aware routing: 10-K/10-Q → curated extraction; everything else
@@ -199,6 +224,9 @@ def process_one(
                     "raw-stored %s %s (form not in full-index allowlist; %d tokens)",
                     ticker, metadata.accession, total_tokens,
                 )
+        # Stamp the code version that produced this tree (issue #57) so a
+        # future index run can tell whether it predates an extraction fix.
+        tree = dataclasses.replace(tree, indexer_commit=indexer_commit)
         with timing.stage("save"):
             save_tree(sec_root, tree)
 
@@ -281,6 +309,7 @@ def run_loop(
                 sec_root=sec_root,
                 client=client,
                 default_model=default_model,
+                indexer_commit=version.commit,
                 logger=logger,
             )
         sleep(poll_interval)

--- a/lib/ai_buffett_zo/indexer/queue.py
+++ b/lib/ai_buffett_zo/indexer/queue.py
@@ -89,6 +89,7 @@ class IndexRequest:
     model: str | None = None
     accession: str | None = None
     priority: int = DEFAULT_PRIORITY
+    force: bool = False             # re-extract even if already indexed (issue #57)
 
     @classmethod
     def new(
@@ -99,6 +100,7 @@ class IndexRequest:
         model: str | None = None,
         accession: str | None = None,
         priority: int | None = None,
+        force: bool = False,
     ) -> IndexRequest:
         return cls(
             id=uuid.uuid4().hex[:12],
@@ -108,6 +110,7 @@ class IndexRequest:
             model=model,
             accession=accession,
             priority=priority if priority is not None else default_priority(form),
+            force=force,
         )
 
 

--- a/lib/ai_buffett_zo/indexer/runtime.py
+++ b/lib/ai_buffett_zo/indexer/runtime.py
@@ -62,6 +62,19 @@ class IndexerHealth:
         return f"Indexer: up to date (commit {running}, started {self.started_at})."
 
 
+def is_tree_stale(existing_commit: str | None, current_commit: str | None) -> bool:
+    """Should a tree built at ``existing_commit`` be re-extracted now? (issue #57)
+
+    True when the running code (``current_commit``) differs from the code that
+    built the tree — including the legacy case where the tree predates commit
+    stamping (``existing_commit`` is None). When the running commit is unknown
+    (no git), we can't tell, so we don't auto-re-extract — ``--force`` still works.
+    """
+    if current_commit is None:
+        return False
+    return existing_commit != current_commit
+
+
 def indexer_health(sec_root: Path) -> IndexerHealth:
     """Compare the running indexer's code against what's installed on disk.
 

--- a/lib/ai_buffett_zo/secrag/storage.py
+++ b/lib/ai_buffett_zo/secrag/storage.py
@@ -185,6 +185,7 @@ def _tree_to_dict(tree: FilingTree) -> dict[str, Any]:
         "sections": [_section_to_dict(s) for s in tree.sections],
         "indexed_at": tree.indexed_at,
         "indexer_model": tree.indexer_model,
+        "indexer_commit": tree.indexer_commit,
     }
 
 
@@ -207,6 +208,7 @@ def _meta_to_dict(tree: FilingTree) -> dict[str, Any]:
         "metadata": asdict(tree.metadata),
         "indexed_at": tree.indexed_at,
         "indexer_model": tree.indexer_model,
+        "indexer_commit": tree.indexer_commit,
         "section_labels": [s.label for s in tree.sections],
     }
 
@@ -219,6 +221,9 @@ def _tree_from_dict(data: dict[str, Any]) -> FilingTree:
         sections=sections,
         indexed_at=_parse_datetime(data["indexed_at"]),
         indexer_model=data["indexer_model"],
+        # Trees indexed before #57 lack this — None means "unknown commit",
+        # which the indexer treats as stale so they get re-extracted.
+        indexer_commit=data.get("indexer_commit"),
     )
 
 

--- a/lib/ai_buffett_zo/secrag/tree.py
+++ b/lib/ai_buffett_zo/secrag/tree.py
@@ -79,12 +79,19 @@ class SectionNode:
 
 @dataclass(frozen=True)
 class FilingTree:
-    """Indexed tree for one filing."""
+    """Indexed tree for one filing.
+
+    ``indexer_commit`` records the code version (git short commit) that
+    produced this tree, so the indexer can re-extract filings built by older
+    code after an extraction fix ships (issue #57). None for trees built before
+    this field existed, or when git wasn't available at index time.
+    """
 
     metadata: FilingMetadata
     sections: list[SectionNode]
     indexed_at: datetime
     indexer_model: str
+    indexer_commit: str | None = None
 
 
 # Sentinel model name used by build_raw_tree — distinguishes raw-stored filings

--- a/skills/clarion-sec-research/SKILL.md
+++ b/skills/clarion-sec-research/SKILL.md
@@ -10,7 +10,7 @@ metadata:
 
 # Clarion SEC research
 
-Four subcommands: `index`, `search`, `status`, `doctor`.
+Five subcommands: `index`, `search`, `status`, `reindex`, `doctor`.
 
 ## When to use
 
@@ -86,17 +86,27 @@ $RESEARCH search "insider transaction" --tickers NVDA  # Form 4 hits
 $RESEARCH status NVDA
 ```
 
+### Reindex
+
+```bash
+$RESEARCH reindex            # whole corpus: re-extract anything built by older code
+$RESEARCH reindex NVDA       # just one ticker
+$RESEARCH reindex --force    # re-extract everything, even if already current
+```
+
+Re-extracts already-indexed filings so the latest extraction fixes reach your existing corpus (issue #57). By default it only re-extracts filings built by **older code** — filings already on the current code are skipped, so it's safe and cheap to re-run. **This is the command to run after upgrading** (after `doctor` confirms the service is current). Without it, an upgrade only affects newly-indexed filings; your existing data keeps its old extraction.
+
 ### Doctor
 
 ```bash
 $RESEARCH doctor
 ```
 
-Checks whether the running `sec-indexer` service is on the **currently installed** code (issue #55). After pulling code updates, the long-running service must be restarted or it keeps executing old code and re-indexing produces wrong data — silently. Run `doctor` after any update (and before a big re-index); if it reports `STALE`, restart the service, then re-index anything indexed since the update. Exit code is non-zero on STALE.
+Checks whether the running `sec-indexer` service is on the **currently installed** code (issue #55). After pulling code updates, the long-running service must be restarted or it keeps executing old code and re-indexing produces wrong data — silently. Run `doctor` after any update (and before a big re-index); if it reports `STALE`, restart the service, then `reindex`. Exit code is non-zero on STALE.
 
 ## Output
 
-Each subcommand prints structured markdown that you should pass through to the user verbatim. `index` confirms the queue submission. `search` returns a hit table and top-5 snippets with citations. `status` shows an **Eval readiness** summary (whether the annual report is indexed yet, plus any high-signal gaps), the indexed filings, and last request state. `doctor` reports indexer code freshness (up to date / STALE / not started).
+Each subcommand prints structured markdown that you should pass through to the user verbatim. `index` confirms the queue submission. `search` returns a hit table and top-5 snippets with citations. `status` shows an **Eval readiness** summary (whether the annual report is indexed yet, plus any high-signal gaps), the indexed filings, and last request state. `reindex` confirms which filings were queued for re-extraction. `doctor` reports indexer code freshness (up to date / STALE / not started).
 
 When you want to **summarize or interpret** the filing content beyond the script's snippets:
 

--- a/skills/clarion-sec-research/scripts/research.py
+++ b/skills/clarion-sec-research/scripts/research.py
@@ -81,7 +81,7 @@ def cmd_index(args: argparse.Namespace) -> int:
         if not args.form:
             print("ERROR: --latest requires --form FORM.", file=sys.stderr)
             return 2
-        req = IndexRequest.new(args.ticker, form=args.form)
+        req = IndexRequest.new(args.ticker, form=args.form, force=args.force)
         enqueue(req, root=qroot)
         _print_index_summary(args.ticker, [(req.form, None, None, req.id)], mode="latest")
         return 0
@@ -110,6 +110,7 @@ def cmd_index(args: argparse.Namespace) -> int:
             args.ticker,
             form=filing.form,
             accession=filing.accession,
+            force=args.force,
         )
         enqueue(req, root=qroot)
         queued.append((filing.form, filing.filed.isoformat(), filing.accession, req.id))
@@ -342,6 +343,49 @@ def cmd_status(args: argparse.Namespace) -> int:
     return 0
 
 
+# ---- reindex ---------------------------------------------------------------
+
+
+def cmd_reindex(args: argparse.Namespace) -> int:
+    """Re-enqueue indexed filings for re-extraction (issue #57).
+
+    No ticker → every indexed filing; a ticker → just that one's. By default the
+    indexer re-extracts only filings built by older code (current ones skip), so
+    this is the safe "apply the latest extraction fixes to my corpus" command
+    after an upgrade. ``--force`` re-extracts everything regardless.
+    """
+    sroot = sec_root()
+    qroot = queue_root()
+    qroot.mkdir(parents=True, exist_ok=True)
+
+    ticker = args.ticker.upper() if args.ticker else None
+    indexed = list_indexed(sroot, ticker=ticker)
+    if not indexed:
+        print(no_data(f"No indexed filings found for {ticker or 'any ticker'}."))
+        return 0
+
+    rows = []
+    for m in indexed:
+        req = IndexRequest.new(m.ticker, form=m.form, accession=m.accession, force=args.force)
+        enqueue(req, root=qroot)
+        rows.append([m.ticker, m.form, m.accession])
+
+    print(header("Re-index queued"))
+    print()
+    verb = "force-re-extract" if args.force else "refresh if built by older code"
+    print(f"Queued {len(rows)} filing(s) to {verb}.")
+    print()
+    print(md_table(["Ticker", "Form", "Accession"], rows))
+    print()
+    print(
+        "The indexer processes these in priority order (10-Ks first); filings "
+        "already on the current code are skipped, so this is safe to re-run."
+    )
+    print()
+    print(footer())
+    return 0
+
+
 # ---- doctor ----------------------------------------------------------------
 
 
@@ -410,7 +454,31 @@ def main() -> int:
             "filing of --form. Mutually exclusive with --days and --count."
         ),
     )
+    p_index.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-extract even if already indexed (issue #57). Default skips current filings.",
+    )
     p_index.set_defaults(func=cmd_index)
+
+    p_reindex = sub.add_parser(
+        "reindex",
+        help=(
+            "Re-extract already-indexed filings to apply the latest extraction "
+            "fixes (issue #57). No ticker = whole corpus. Only filings built by "
+            "older code are re-extracted unless --force."
+        ),
+    )
+    p_reindex.add_argument(
+        "ticker", nargs="?", default=None, type=str.upper,
+        help="Limit to one ticker (default: every indexed filing).",
+    )
+    p_reindex.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-extract every filing, not just those built by older code.",
+    )
+    p_reindex.set_defaults(func=cmd_reindex)
 
     p_search = sub.add_parser("search", help="Search indexed filings by keyword.")
     p_search.add_argument("query")

--- a/skills/clarion-setup/SKILL.md
+++ b/skills/clarion-setup/SKILL.md
@@ -210,7 +210,9 @@ Editable installs (`uv pip install -e`) do NOT reload an already-running service
 
 A full setup re-run handles this: the clean-re-run path jumps to Step 5b (restart unconditionally), and Step 6's `clarion-sec-research doctor` check then confirms the running code matches what's installed. **Always let the restart happen on a re-run — do not skip Step 5b even if config is unchanged.**
 
-If code was updated **outside** this flow (a bare `git pull` without re-running setup), the service is almost certainly stale. Run `clarion-sec-research doctor`; if it reports STALE, restart the `sec-indexer` service and then re-index anything indexed since the update, since those filings were processed by the old code.
+If code was updated **outside** this flow (a bare `git pull` without re-running setup), the service is almost certainly stale. Run `clarion-sec-research doctor`; if it reports STALE, restart the `sec-indexer` service first.
+
+**Applying extraction fixes to an already-indexed corpus (issue #57).** A code update only changes how filings are *parsed*; it does not touch filings already on disk. After confirming the service is current (`doctor` → up to date), run `clarion-sec-research reindex` to re-extract the existing corpus. It re-extracts only filings built by older code (current ones skip), so it's safe to run after every upgrade — and necessary for extraction/parsing fixes to reach data the user indexed before the upgrade.
 
 ## On error
 

--- a/tests/test_indexer_main.py
+++ b/tests/test_indexer_main.py
@@ -416,3 +416,93 @@ def test_run_loop_writes_runtime_marker(tmp_path: Path) -> None:
     )
     marker = sec_root / ".indexer_runtime.json"
     assert marker.exists()
+
+
+# ---- re-extract on upgrade (issue #57) -------------------------------------
+
+
+def _save_tree_with_commit(sec_root: Path, commit: str | None) -> None:
+    import dataclasses
+    from ai_buffett_zo.secrag import save_tree
+    save_tree(sec_root, dataclasses.replace(_tree(_meta()), indexer_commit=commit))
+
+
+def test_process_one_skips_when_commit_matches(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    queue_root, sec_root = tmp_path / "queue", tmp_path / "sec"
+    captured = _patch_pipeline(monkeypatch)
+    _save_tree_with_commit(sec_root, "abc123")
+    r = IndexRequest.new("NVDA", "10-K")
+    enqueue(r, root=queue_root)
+    main_mod.process_one(
+        r.id, queue_root=queue_root, sec_root=sec_root,
+        client=ZoClient(token="zo_sk_test"), default_model="m",
+        logger=_logger(), indexer_commit="abc123",
+    )
+    assert captured["built"] == []  # current → skipped
+    assert (queue_root / ".done" / f"{r.id}.json").exists()
+
+
+def test_process_one_reextracts_when_commit_differs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    queue_root, sec_root = tmp_path / "queue", tmp_path / "sec"
+    captured = _patch_pipeline(monkeypatch)
+    _save_tree_with_commit(sec_root, "OLD")
+    r = IndexRequest.new("NVDA", "10-K")
+    enqueue(r, root=queue_root)
+    main_mod.process_one(
+        r.id, queue_root=queue_root, sec_root=sec_root,
+        client=ZoClient(token="zo_sk_test"), default_model="m",
+        logger=_logger(), indexer_commit="NEW",
+    )
+    assert captured["built"]  # stale → re-extracted
+
+
+def test_process_one_reextracts_legacy_tree_without_commit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    queue_root, sec_root = tmp_path / "queue", tmp_path / "sec"
+    captured = _patch_pipeline(monkeypatch)
+    _save_tree_with_commit(sec_root, None)  # pre-#57 tree
+    r = IndexRequest.new("NVDA", "10-K")
+    enqueue(r, root=queue_root)
+    main_mod.process_one(
+        r.id, queue_root=queue_root, sec_root=sec_root,
+        client=ZoClient(token="zo_sk_test"), default_model="m",
+        logger=_logger(), indexer_commit="NEW",
+    )
+    assert captured["built"]  # None != "NEW" → re-extracted
+
+
+def test_process_one_force_reextracts_current_tree(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    queue_root, sec_root = tmp_path / "queue", tmp_path / "sec"
+    captured = _patch_pipeline(monkeypatch)
+    _save_tree_with_commit(sec_root, "SAME")
+    r = IndexRequest.new("NVDA", "10-K", force=True)
+    enqueue(r, root=queue_root)
+    main_mod.process_one(
+        r.id, queue_root=queue_root, sec_root=sec_root,
+        client=ZoClient(token="zo_sk_test"), default_model="m",
+        logger=_logger(), indexer_commit="SAME",
+    )
+    assert captured["built"]  # forced despite matching commit
+
+
+def test_process_one_stamps_commit_on_new_tree(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    queue_root, sec_root = tmp_path / "queue", tmp_path / "sec"
+    _patch_pipeline(monkeypatch)
+    r = IndexRequest.new("NVDA", "10-K")
+    enqueue(r, root=queue_root)
+    main_mod.process_one(
+        r.id, queue_root=queue_root, sec_root=sec_root,
+        client=ZoClient(token="zo_sk_test"), default_model="m",
+        logger=_logger(), indexer_commit="stamp7",
+    )
+    from ai_buffett_zo.secrag import load_tree
+    assert load_tree(sec_root, "NVDA", "acc-1").indexer_commit == "stamp7"

--- a/tests/test_indexer_queue.py
+++ b/tests/test_indexer_queue.py
@@ -203,3 +203,15 @@ def test_list_pending_backfills_priority_from_form_for_legacy_files(tmp_path: Pa
     # Legacy 10-K backfills to P1, so it sorts ahead of the newer P2 8-K.
     assert [p.ticker for p in pending] == ["OLD", "NEW"]
     assert pending[0].priority == PRIORITY_P1
+
+
+def test_index_request_force_defaults_false() -> None:
+    assert IndexRequest.new("NVDA").force is False
+
+
+def test_index_request_force_persists_through_enqueue(tmp_path: Path) -> None:
+    r = IndexRequest.new("NVDA", "10-K", force=True)
+    path = enqueue(r, root=tmp_path)
+    assert json.loads(path.read_text())["force"] is True
+    # And survives the read-back in list_pending.
+    assert list_pending(tmp_path)[0].force is True

--- a/tests/test_indexer_runtime.py
+++ b/tests/test_indexer_runtime.py
@@ -67,3 +67,12 @@ def test_health_handles_corrupt_marker(tmp_path: Path) -> None:
     (tmp_path / runtime_mod.RUNTIME_MARKER).write_text("not json")
     h = indexer_health(tmp_path)
     assert h.running is False  # treated as missing rather than crashing
+
+
+def test_is_tree_stale() -> None:
+    from ai_buffett_zo.indexer import is_tree_stale
+    assert is_tree_stale("old", "new") is True       # built by older code
+    assert is_tree_stale(None, "new") is True         # legacy tree (pre-#57)
+    assert is_tree_stale("same", "same") is False      # current
+    assert is_tree_stale("old", None) is False         # our commit unknown → don't auto-reextract
+    assert is_tree_stale(None, None) is False

--- a/tests/test_research_skill.py
+++ b/tests/test_research_skill.py
@@ -99,6 +99,7 @@ def _ns(ticker: str, **kwargs) -> argparse.Namespace:
         days=kwargs.get("days"),
         count=kwargs.get("count"),
         latest=kwargs.get("latest", False),
+        force=kwargs.get("force", False),
     )
 
 
@@ -495,3 +496,53 @@ def test_cmd_doctor_reports_stale(
     assert "STALE" in out
     assert "Restart the `sec-indexer` service" in out
     assert rc == 1  # non-zero so callers can gate on it
+
+
+# ---- cmd_reindex + index --force (issue #57) -------------------------------
+
+
+def test_cmd_index_force_flag_enqueues_force(research_mod, roots: tuple[Path, Path]) -> None:
+    from ai_buffett_zo.indexer import list_pending
+    queue_root, _ = roots
+    research_mod.cmd_index(_ns("NVDA", form="10-K", latest=True, force=True))
+    assert list_pending(queue_root)[0].force is True
+
+
+def test_cmd_reindex_enqueues_all_indexed(
+    research_mod, roots: tuple[Path, Path], capsys: pytest.CaptureFixture[str]
+) -> None:
+    from ai_buffett_zo.indexer import list_pending
+    queue_root, sec_root = roots
+    save_tree(sec_root, _make_filing("NVDA", accession="acc-nvda"))
+    save_tree(sec_root, _make_filing("AAPL", accession="acc-aapl"))
+    rc = research_mod.cmd_reindex(argparse.Namespace(ticker=None, force=False))
+    assert rc == 0
+    pending = list_pending(queue_root)
+    assert {p.ticker for p in pending} == {"NVDA", "AAPL"}
+    assert all(p.force is False for p in pending)  # default: refresh-if-stale, not force
+    assert "Re-index queued" in capsys.readouterr().out
+
+
+def test_cmd_reindex_per_ticker(research_mod, roots: tuple[Path, Path]) -> None:
+    from ai_buffett_zo.indexer import list_pending
+    queue_root, sec_root = roots
+    save_tree(sec_root, _make_filing("NVDA", accession="acc-nvda"))
+    save_tree(sec_root, _make_filing("AAPL", accession="acc-aapl"))
+    research_mod.cmd_reindex(argparse.Namespace(ticker="NVDA", force=False))
+    assert [p.ticker for p in list_pending(queue_root)] == ["NVDA"]
+
+
+def test_cmd_reindex_force_sets_flag(research_mod, roots: tuple[Path, Path]) -> None:
+    from ai_buffett_zo.indexer import list_pending
+    queue_root, sec_root = roots
+    save_tree(sec_root, _make_filing("NVDA", accession="acc-nvda"))
+    research_mod.cmd_reindex(argparse.Namespace(ticker="NVDA", force=True))
+    assert list_pending(queue_root)[0].force is True
+
+
+def test_cmd_reindex_no_indexed_filings(
+    research_mod, roots: tuple[Path, Path], capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc = research_mod.cmd_reindex(argparse.Namespace(ticker=None, force=False))
+    assert rc == 0
+    assert "No indexed filings" in capsys.readouterr().out

--- a/tests/test_secrag_storage.py
+++ b/tests/test_secrag_storage.py
@@ -84,6 +84,21 @@ def test_tree_roundtrip_preserves_all_fields(tmp_path: Path) -> None:
     assert s.chunks[0].text == "Chunk text 0"
 
 
+def test_tree_roundtrip_preserves_indexer_commit(tmp_path: Path) -> None:
+    import dataclasses
+    tree = dataclasses.replace(_tree(), indexer_commit="abc1234")
+    save_tree(tmp_path, tree)
+    loaded = load_tree(tmp_path, tree.metadata.ticker, tree.metadata.accession)
+    assert loaded.indexer_commit == "abc1234"
+
+
+def test_tree_load_defaults_commit_none_for_legacy(tmp_path: Path) -> None:
+    # A tree without a commit (legacy / pre-#57) loads as None, not a crash.
+    save_tree(tmp_path, _tree())
+    loaded = load_tree(tmp_path, "NVDA", _tree().metadata.accession)
+    assert loaded.indexer_commit is None
+
+
 def test_save_tree_writes_meta_alongside(tmp_path: Path) -> None:
     tree = _tree()
     save_tree(tmp_path, tree)


### PR DESCRIPTION
## Summary

Closes #57. The keystone for a clean user release. The indexer skipped any filing whose tree already existed, so the extraction-correctness fixes we shipped (#53 anchor, #45 iXBRL, #47 MD&A) **never reached already-indexed filings** — a re-index was a silent no-op. Confirmed on the canonical Zo: the corpus scan showed pre-#53 output for accessions that extract correctly with current code.

Without this, "re-run set up Clarion" would leave existing users with their old broken sections. With it, the upgrade prompt is honest: **re-run setup, then `reindex`.**

## How it works

- **`FilingTree.indexer_commit`** — every tree records the git short commit that built it (round-tripped through storage; `None` for legacy trees). Stamped in `process_one` from the running commit (computed once at service start, builds on #55).
- **Stale-aware skip** — when a filing is already indexed, `process_one` re-extracts if `force` OR the stored commit differs from the running commit (`is_tree_stale`; legacy `None` counts as stale). Filings already on current code still skip, so routine re-indexing stays cheap. When the running commit is unknown (no git), it does **not** auto-re-extract — `--force` is the escape hatch.
- **`index --force`** and a new **`reindex [TICKER] [--force]`** — `reindex` re-enqueues indexed filings (whole corpus or one ticker) for re-extraction; by default only stale ones actually rebuild, so it's safe to re-run. This is the one-command post-upgrade refresh.

## Why this shape

Ties to #55's version stamp: the tree carries the commit it was built with, so the indexer can tell "this was extracted by older code" and refresh automatically on the next `reindex` — no manual `rm`, no flags to remember. Distinct from #55 (which ensures the *service* runs current code); even on a current service, the old skip-if-indexed logic blocked propagation.

## Tests (+15, 767 total)
Commit round-trips through storage (+ legacy `None`); `IndexRequest.force` persists; `is_tree_stale` truth table; `process_one` skip-when-current / re-extract-when-stale / re-extract-legacy / `--force` / stamps-commit-on-new-tree; `reindex` enqueues all / per-ticker / `--force` / empty-corpus; `index --force`. Full suite green; lint clean.

## Release sequencing
This unblocks the user-facing upgrade prompt. After merge: canonical Zo runs `set up Clarion` → `doctor` (up to date) → `reindex` → re-run the corpus scan (degenerate count should collapse to MSFT/SYF/INTC = #54). Then ship the prompt to all users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)