### PR TITLE
fix(portfolio,monitor): correct 30-day NLV delta + surface unscored active theses

### DIFF
--- a/skills/clarion-portfolio-monitor/scripts/fetch.py
+++ b/skills/clarion-portfolio-monitor/scripts/fetch.py
@@ -25,12 +25,51 @@ import asyncio
 import json
 import os
 import sys
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
 
+try:
+    import duckdb as _duckdb
+except ImportError:
+    _duckdb = None
+
 CLARION_DATA_ROOT = os.environ.get("CLARION_DATA_ROOT", "/home/workspace/clarion")
 PORTFOLIO_DIR = Path(CLARION_DATA_ROOT) / "portfolio"
+
+
+def _duckdb_nlv_change(days: int = 30) -> tuple[float, float, int] | None:
+    """Query DuckDB for NLV change over the last N days (authoritative source).
+
+    Returns (nlv_n_days_ago, current_nlv, actual_days) or None if DuckDB
+    unavailable or insufficient history.
+    """
+    if _duckdb is None:
+        return None
+    db_path = PORTFOLIO_DIR / "portfolio.duckdb"
+    if not db_path.exists():
+        return None
+    try:
+        con = _duckdb.connect(str(db_path), read_only=True)
+        target_date = (date.today() - timedelta(days=days)).isoformat()
+        row = con.execute(
+            "SELECT date, nlv FROM portfolio_daily "
+            "WHERE date <= ? ORDER BY date DESC LIMIT 1",
+            [target_date],
+        ).fetchone()
+        latest = con.execute(
+            "SELECT date, nlv FROM portfolio_daily ORDER BY date DESC LIMIT 1"
+        ).fetchone()
+        con.close()
+        if not row or not latest:
+            return None
+        old_date = date.fromisoformat(str(row[0]))
+        latest_date = date.fromisoformat(str(latest[0]))
+        actual_days = (latest_date - old_date).days
+        return (float(row[1]), float(latest[1]), actual_days)
+    except Exception:
+        return None
+
 
 class DecimalEncoder(json.JSONEncoder):
     def default(self, obj):
@@ -171,7 +210,7 @@ async def main():
         if not args.no_history:
             try:
                 print(f"Fetching NLV history for {acct_number}...", file=sys.stderr)
-                nl_history = await acct.get_net_liquidating_value_history(session, time_back="1m")
+                nl_history = await acct.get_net_liquidating_value_history(session, time_back="3m")
                 nl_points = []
                 for pt in nl_history[-30:]:
                     nl_points.append({
@@ -273,14 +312,31 @@ async def main():
                 lines.append(f"- **{tx['type']}** — {tx['description']} ({fmt_dollar(tx['value'])})")
             lines.append("")
 
-        if acct_data.get("nlv_history_30d") and len(acct_data["nlv_history_30d"]) >= 2:
+        # 30-Day NLV Change — DuckDB authoritative, API history fallback
+        duckdb_result = _duckdb_nlv_change(30)
+        if duckdb_result:
+            old_nlv, latest_nlv, actual_days = duckdb_result
+            change = latest_nlv - old_nlv
+            change_pct = (change / old_nlv) * 100 if old_nlv else 0
+            label = "30-Day" if actual_days >= 25 else f"{actual_days}-Day"
+            lines.append(f"**{label} NLV Change:** {fmt_dollar(change)} ({fmt_pct(change_pct)}) [DuckDB authoritative]")
+            lines.append("")
+        elif acct_data.get("nlv_history_30d") and len(acct_data["nlv_history_30d"]) >= 2:
             history = acct_data["nlv_history_30d"]
             first = history[0]["close"]
             last = history[-1]["close"]
             if first and last:
                 change = last - first
                 change_pct = (change / first) * 100
-                lines.append(f"**30-Day NLV Change:** {fmt_dollar(change)} ({fmt_pct(change_pct)})")
+                # Compute actual day span from timestamps for accurate labeling
+                try:
+                    first_dt = datetime.fromisoformat(history[0]["time"])
+                    last_dt = datetime.fromisoformat(history[-1]["time"])
+                    actual_days = (last_dt.date() - first_dt.date()).days
+                except (ValueError, KeyError):
+                    actual_days = 0
+                label = "30-Day" if actual_days >= 25 else f"{actual_days}-Day" if actual_days > 0 else "Period"
+                lines.append(f"**{label} NLV Change:** {fmt_dollar(change)} ({fmt_pct(change_pct)}) [API fallback]")
                 lines.append("")
 
     lines.append("---")

--- a/skills/clarion-thesis-monitor/scripts/monitor.py
+++ b/skills/clarion-thesis-monitor/scripts/monitor.py
@@ -371,6 +371,7 @@ def run(args: argparse.Namespace) -> int:
     asof = date.today()
     rows: list[tuple[ThesisMetadata, HealthSnapshot, list[str]]] = []
     malformed: list[Path] = []
+    unscored: list[Path] = []
     for path in paths:
         try:
             result = _process_thesis(
@@ -388,21 +389,38 @@ def run(args: argparse.Namespace) -> int:
             malformed.append(path)
             continue
         if result is None:
+            # Diagnose skip reason: not-active (expected) vs. unscored (actionable)
+            content = path.read_text()
+            meta = parse_thesis_metadata(content)
+            if meta is not None and meta.status == "active":
+                comps, _ = parse_health_components(content)
+                if not comps:
+                    unscored.append(path)
             continue
         rows.append(result)
 
     if not rows:
         print(
-            "THESIS_MONITOR_ERROR: no active theses to monitor "
-            "(parsed but all status != active — drafts, watchlist, closed, "
-            "and killed theses are skipped — or all malformed)."
+            "THESIS_MONITOR_ERROR: no monitorable theses found."
         )
+        if unscored:
+            print("  Active but UNSCORED (no health_components — run clarion-thesis-write or score manually):")
+            for p in unscored:
+                print(f"    unscored: {p.name}")
         if malformed:
             for p in malformed:
-                print(f"  malformed: {p.name}")
+                print(f"    malformed: {p.name}")
+        if not unscored and not malformed:
+            print("  (all theses are draft/watchlist/closed/killed — expected if no active positions)")
         return 1
 
     _render_dashboard(rows, regime, quick=args.quick, write=not args.no_write)
+
+    if unscored:
+        print()
+        print("## Unscored Active Theses (skipped — no health_components)")
+        for p in unscored:
+            print(f"- {p.name} — run clarion-thesis-write or populate health_components to enable monitoring")
 
     if malformed:
         print()

--- a/tests/test_thesis_monitor_skill.py
+++ b/tests/test_thesis_monitor_skill.py
@@ -187,7 +187,7 @@ def test_run_errors_when_only_inactive_theses(
     rc = monitor_mod.run(_args())
     assert rc == 1
     out = capsys.readouterr().out
-    assert "no active theses" in out
+    assert "no monitorable theses" in out
 
 
 def test_run_skips_draft_theses(
@@ -202,7 +202,7 @@ def test_run_skips_draft_theses(
     rc = monitor_mod.run(_args())
     assert rc == 1
     out = capsys.readouterr().out
-    assert "no active theses" in out
+    assert "no monitorable theses" in out
     # Error message must mention drafts so users know what's going on.
     assert "draft" in out.lower()
 


### PR DESCRIPTION
## Summary

Two bugs found during the 2026-06-26 portfolio review. Both were fixed and verified live in the workspace runtime before porting to this branch.

## Bug 1 — `fetch.py`: 30-day NLV change was silently wrong

**Root cause:** `get_net_liquidating_value_history(time_back='1m')` returns only ~5 weekly snapshots, not 30 daily points. The code took first→last of whatever was returned and labeled it "30-Day NLV Change" regardless of the actual time span.

**Impact on 2026-06-26:** snapshot reported `+$40.12 (+0.41%)` — a 4-day delta mislabeled as 30-day. Real 30-day change (DuckDB authoritative): **-$430.22 (-4.23%)**. Every daily snapshot since launch (May 8) carried a wrong number.

**Fix:**
- Query DuckDB (`portfolio.duckdb`, read-only) for the NLV closest to N days ago vs the latest row. Labels output `N-Day NLV Change [DuckDB authoritative]` with the true day span.
- Falls back to TastyTrade API history (`time_back='3m'` for more data), labeled with the actual span + `[API fallback]` tag.
- Optional `import duckdb` guard — script still runs without it.

**Verified:** re-ran `fetch.py`; snapshot now reports `30-Day NLV Change: -$430.22 (-4.23%) [DuckDB authoritative]`, matching the DuckDB query exactly.

## Bug 2 — `monitor.py`: active-but-unscored theses silently skipped

**Root cause:** `_process_thesis` returns `None` both when `status != 'active'` (expected skip) AND when `health_components` is empty (actionable gap). The error message said "no active theses" for both, masking the real problem.

**Impact on 2026-06-26:** TTD and UBER (both `status: active`) were silently dropped because they have no `health_components` populated — indistinguishable from "no active positions at all." A reviewer would conclude the portfolio has fewer active theses than it does.

**Fix:** in `run()`, when `_process_thesis` returns `None`, re-parse the thesis to diagnose the skip reason. Active-but-unscored theses are collected into an `unscored` list and surfaced in a dedicated section with actionable guidance. The error message now distinguishes unscored / malformed / expected (draft/watchlist/closed/killed).

**Verified:** `monitor --ticker TTD` now prints `Active but UNSCORED (no health_components...)` instead of the misleading "no active theses." Full run surfaces TTD + UBER in a `## Unscored Active Theses` section while processing the 13 scored theses normally.

## What's NOT in this PR

Pre-existing uncommitted v2 LLM-scoring WIP (`llm_scores.py`, `__init__.py` export, `_recompute_components` content param) was stashed to isolate this bugfix. No v2 changes included.

## Test plan
- [x] `python3 -m py_compile` both files pass
- [x] `fetch.py` re-run: NLV change matches DuckDB authoritative value
- [x] `monitor.py --ticker TTD`: correct diagnostic instead of misleading error
- [x] Full `monitor.py --no-write` run: 13 scored theses processed + unscored section shown
- [x] `git diff` confirms no v2 WIP leaked into this branch