### PR TITLE
feat(thesis-write): mobile-responsive templates + font stack, branding as placeholders

### DIFF
--- a/skills/clarion-thesis-write/SKILL.md
+++ b/skills/clarion-thesis-write/SKILL.md
@@ -78,3 +78,16 @@ The thesis should be **conversational and direct** — the style described in [`
 - **`THESIS_WRITE_ERROR: file already exists`** — pass `--force` to overwrite, or pick a different filename.
 - **`THESIS_WRITE_ERROR: failed to fetch fundamentals`** — yfinance hiccup. Retry, or pass `--no-fundamentals` to skip the snapshot pre-fill.
 - **`THESIS_WRITE_ERROR: ticker not indexed`** — only when `--require-indexed` is set. Run `clarion-sec-research index <TICKER>` first.
+
+## Zo Space page templates
+
+`assets/zo-space-page-template.tsx` (Add/Hold, 5 tabs) and
+`assets/zo-space-page-template-skip.tsx` (Skip, 4 sections) are the canonical
+starting points for public thesis pages at `/{ticker}`. Both are
+mobile-responsive (grids collapse below 640px) and load Newsreader/Inter fonts.
+
+Fill every `{{PLACEHOLDER}}` before publishing. Branding placeholders:
+
+- `{{BRAND_NAME}}` — nav brand text (e.g. "Clarion Intelligence Systems"); rendered as a link
+- `{{BRAND_URL}}` — where the nav brand links (your site's homepage)
+- `{{FOOTER_ATTRIBUTION}}` — footer byline (e.g. "Your Name · Your Firm")

--- a/skills/clarion-thesis-write/assets/zo-space-page-template-skip.tsx
+++ b/skills/clarion-thesis-write/assets/zo-space-page-template-skip.tsx
@@ -26,6 +26,9 @@ const theme = {
   red: "#FA4D56",
   yellow: "#F1C21B",
   kill: "#FA4D56",
+  serif: "'Newsreader', 'Tiempos Headline', Georgia, serif",
+  sans: "'Inter', 'Suisse Intl', -apple-system, BlinkMacSystemFont, sans-serif",
+  mono: "ui-monospace, 'SF Mono', Menlo, Consolas, monospace",
 };
 
 // ---- LIVE DATA (must be fetched before writing) ----
@@ -88,10 +91,19 @@ export default function SkipEval() {
   } as React.CSSProperties);
 
   return (
-    <div style={{ background: theme.bg, color: theme.fg, fontFamily: "'Inter', system-ui, sans-serif", minHeight: "100vh" }}>
+    <div className="thesis-root" style={{ background: theme.bg, color: theme.fg, fontFamily: theme.sans, minHeight: "100vh" }}>
+      <style>{`
+        @import url('https://fonts.googleapis.com/css2?family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,600;6..72,700&family=Inter:wght@400;500;600;700&display=swap');
+        .thesis-root * { border-radius: 0 !important; }
+        /* Mobile: collapse grids so cards never overflow the viewport (max-width 640px = phones) */
+        @media (max-width:640px){
+          .thesis-metrics { grid-template-columns:repeat(3,minmax(0,1fr)) !important; }
+          .thesis-scenarios { grid-template-columns:1fr !important; }
+        }
+      `}</style>
       {/* NAV */}
       <div style={{ borderBottom: `1px solid ${theme.border}`, padding: "12px 24px", display: "flex", justifyContent: "space-between", alignItems: "center", background: "rgba(0,0,0,0.6)" }}>
-        <span style={{ fontSize: 12, color: theme.muted, letterSpacing: "0.08em", textTransform: "uppercase" }}>Clarion Intelligence Systems</span>
+        <a href="{{BRAND_URL}}" style={{ fontSize: 12, color: theme.fg, letterSpacing: "0.08em", textTransform: "uppercase", textDecoration: "none" }}>{{BRAND_NAME}}</a>
         <span style={{ fontSize: 11, color: theme.muted }}>{{REGIME_LINE}}</span>
       </div>
 
@@ -128,7 +140,7 @@ export default function SkipEval() {
         </div>
 
         {/* STATS BAR */}
-        <div style={{ display: "grid", gridTemplateColumns: `repeat(${Math.min(tickerItems.length, 6)}, 1fr)`, gap: 10, marginBottom: 24 }}>
+        <div className="thesis-metrics" style={{ display: "grid", gridTemplateColumns: `repeat(${Math.min(tickerItems.length, 6)}, minmax(0,1fr))`, gap: 10, marginBottom: 24 }}>
           {tickerItems.map(([label, value]) => (
             <div key={label} style={{ background: theme.card, border: `1px solid ${theme.border}`, borderRadius: 10, padding: "12px 10px", textAlign: "center" }}>
               <div style={{ fontSize: 16, fontWeight: 700, color: value.startsWith("-") ? theme.red : theme.accent }}>{value}</div>
@@ -183,7 +195,7 @@ export default function SkipEval() {
           <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
             <div style={{ background: theme.card, border: `1px solid ${theme.border}`, borderRadius: 12, padding: 22 }}>
               <div style={{ fontSize: 12, color: theme.accent, textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 18 }}>Valuation Scenarios</div>
-              <div style={{ display: "grid", gridTemplateColumns: `repeat(${valuationScenarios.length}, 1fr)`, gap: 12 }}>
+              <div className="thesis-scenarios" style={{ display: "grid", gridTemplateColumns: `repeat(${valuationScenarios.length}, minmax(0,1fr))`, gap: 12 }}>
                 {valuationScenarios.map((s) => (
                   <div key={s.label} style={{ background: s.color + "0D", border: `1px solid ${s.color}33`, borderRadius: 10, padding: 16 }}>
                     <div style={{ fontSize: 11, color: s.color, fontWeight: 700, textTransform: "uppercase", marginBottom: 8 }}>{s.label}</div>
@@ -223,8 +235,8 @@ export default function SkipEval() {
 
         {/* FOOTER */}
         <div style={{ marginTop: 32, padding: "14px 0", borderTop: `1px solid ${theme.border}`, display: "flex", justifyContent: "space-between", fontSize: 11, color: theme.muted }}>
-          <span>Clarion Intelligence Systems LLC -- Research only, not investment advice</span>
-          <span>Price: yfinance -- SEC: EDGAR ({{ACCESSION}}) -- {dataTs}</span>
+          <span>{{FOOTER_ATTRIBUTION}}</span>
+          <span>Research only, not investment advice · Price: yfinance -- SEC: EDGAR ({{ACCESSION}}) -- {dataTs}</span>
         </div>
       </div>
     </div>

--- a/skills/clarion-thesis-write/assets/zo-space-page-template.tsx
+++ b/skills/clarion-thesis-write/assets/zo-space-page-template.tsx
@@ -27,6 +27,9 @@ const theme = {
   red: "#FA4D56",
   yellow: "#F1C21B",
   kill: "#FA4D56",
+  serif: "'Newsreader', 'Tiempos Headline', Georgia, serif",
+  sans: "'Inter', 'Suisse Intl', -apple-system, BlinkMacSystemFont, sans-serif",
+  mono: "ui-monospace, 'SF Mono', Menlo, Consolas, monospace",
 };
 
 // ---- LIVE DATA (must be fetched before writing) ----
@@ -88,10 +91,26 @@ export default function {{COMPONENT_NAME}}() {
   const scoreColor = (s: number|null) => s === null ? theme.muted : s >= 70 ? theme.green : s >= 30 ? theme.accent : theme.red;
 
   return (
-    <div style={{ background: theme.bg, color: theme.fg, fontFamily: "'Inter', system-ui, sans-serif", minHeight: "100vh" }}>
+    <div className="thesis-root" style={{ background: theme.bg, color: theme.fg, fontFamily: theme.sans, minHeight: "100vh" }}>
+      <style>{`
+        @import url('https://fonts.googleapis.com/css2?family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,600;6..72,700&family=Inter:wght@400;500;600;700&display=swap');
+        .thesis-root * { border-radius: 0 !important; }
+        /* Mobile: collapse grids so cards/columns never overflow the viewport (max-width 640px = phones) */
+        @media (max-width:640px){
+          .thesis-metrics { grid-template-columns:repeat(3,minmax(0,1fr)) !important; }
+          .thesis-scenarios { grid-template-columns:1fr !important; }
+          .thesis-sizing { grid-template-columns:1fr !important; }
+          .thesis-screener-sum { grid-template-columns:1fr !important; }
+          .thesis-factor-row { grid-template-columns:16px 1fr 56px !important; }
+          .thesis-factor-row > *:nth-child(3),
+          .thesis-factor-row > *:nth-child(4),
+          .thesis-factor-row > *:nth-child(6),
+          .thesis-factor-row > *:nth-child(7) { display:none !important; }
+        }
+      `}</style>
       {/* NAV */}
       <div style={{ borderBottom: `1px solid ${theme.border}`, padding: "12px 24px", display: "flex", justifyContent: "space-between", alignItems: "center", background: "rgba(0,0,0,0.6)" }}>
-        <span style={{ fontSize: 12, color: theme.muted, letterSpacing: "0.08em", textTransform: "uppercase" }}>Clarion Intelligence Systems</span>
+        <a href="{{BRAND_URL}}" style={{ fontSize: 12, color: theme.fg, letterSpacing: "0.08em", textTransform: "uppercase", textDecoration: "none" }}>{{BRAND_NAME}}</a>
         <span style={{ fontSize: 11, color: theme.muted }}>{{REGIME_LINE}}</span>
       </div>
 
@@ -130,7 +149,7 @@ export default function {{COMPONENT_NAME}}() {
         </div>
 
         {/* STATS BAR */}
-        <div style={{ display: "grid", gridTemplateColumns: "repeat(6,1fr)", gap: 10, marginBottom: 24 }}>
+        <div className="thesis-metrics" style={{ display: "grid", gridTemplateColumns: "repeat(6,minmax(0,1fr))", gap: 10, marginBottom: 24 }}>
           {{STATS_BAR_ITEMS}}
         </div>
 
@@ -195,7 +214,7 @@ export default function {{COMPONENT_NAME}}() {
           <div style={{ display:"flex",flexDirection:"column",gap:16 }}>
             <div style={{ background:theme.card,border:`1px solid ${theme.border}`,borderRadius:12,padding:22 }}>
               <div style={{ fontSize:12,color:theme.accent,textTransform:"uppercase",letterSpacing:"0.08em",marginBottom:16 }}>Bear / Base / Bull</div>
-              <div style={{ display:"grid",gridTemplateColumns:`repeat(${valuationScenarios.length},1fr)`,gap:12 }}>
+              <div className="thesis-scenarios" style={{ display:"grid",gridTemplateColumns:`repeat(${valuationScenarios.length},minmax(0,1fr))`,gap:12 }}>
                 {valuationScenarios.map(s => {
                   const isBear = s.label === "Bear";
                   const isBase = s.label === "Base";
@@ -218,7 +237,7 @@ export default function {{COMPONENT_NAME}}() {
         {/* TAB: POSITION MGMT */}
         {tab==="position" && (
           <div style={{ display:"flex",flexDirection:"column",gap:14 }}>
-            <div style={{ display:"grid",gridTemplateColumns:"1fr 1fr",gap:14 }}>
+            <div className="thesis-sizing" style={{ display:"grid",gridTemplateColumns:"1fr 1fr",gap:14 }}>
               <div style={{ background:theme.card,border:`1px solid ${theme.border}`,borderRadius:12,padding:18 }}>
                 <div style={{ fontSize:12,color:theme.accent,textTransform:"uppercase",letterSpacing:"0.08em",marginBottom:12 }}>Sizing</div>
                 {{SIZING_ROWS}}
@@ -235,7 +254,7 @@ export default function {{COMPONENT_NAME}}() {
         {/* TAB: SCREENER */}
         {tab === "screener" && (
           <div style={{ display:"flex", flexDirection:"column", gap:16 }}>
-            <div style={{ display:"grid", gridTemplateColumns:"1fr 1fr 1fr", gap:12 }}>
+            <div className="thesis-screener-sum" style={{ display:"grid", gridTemplateColumns:"1fr 1fr 1fr", gap:12 }}>
               {screenerSummary.map(([l,v])=>(
                 <div key={l} style={{ background:theme.card, border:`1px solid ${theme.border}`, borderRadius:10, padding:"14px 16px", textAlign:"center" }}>
                   <div style={{ fontSize:22, fontWeight:700, color:theme.accent }}>{v}</div>
@@ -264,11 +283,11 @@ export default function {{COMPONENT_NAME}}() {
               <div style={{ fontSize:11, color:theme.muted, marginBottom:14, padding:"8px 12px", background:theme.accentSoft, borderRadius:6 }}>
                 {{SCREENER_FORMULA_LINE}}
               </div>
-              <div style={{ display:"grid", gridTemplateColumns:"16px 110px 40px 90px 72px 1fr 190px", gap:8, padding:"6px 10px", marginBottom:4 }}>
+              <div className="thesis-factor-row" style={{ display:"grid", gridTemplateColumns:"16px 110px 40px 90px 72px 1fr 190px", gap:8, padding:"6px 10px", marginBottom:4 }}>
                 {["","Factor","Wt","Raw","Score /100","","Notes"].map((h,i)=>( <span key={i} style={{ fontSize:10, color:theme.muted, textTransform:"uppercase", letterSpacing:"0.06em" }}>{h}</span> ))}
               </div>
               {screenerFactors.map(f=>(
-                <div key={f.key} style={{ display:"grid", gridTemplateColumns:"16px 110px 40px 90px 72px 1fr 190px", alignItems:"center", gap:8, padding:"8px 10px", background:"rgba(255,255,255,0.02)", borderRadius:8, marginBottom:4 }}>
+                <div key={f.key} className="thesis-factor-row" style={{ display:"grid", gridTemplateColumns:"16px 110px 40px 90px 72px 1fr 190px", alignItems:"center", gap:8, padding:"8px 10px", background:"rgba(255,255,255,0.02)", borderRadius:8, marginBottom:4 }}>
                   <div style={{ width:8, height:8, borderRadius:"50%", background:scoreColor(f.score) }}/>
                   <span style={{ fontSize:13, fontWeight:600 }}>{f.key}</span>
                   <span style={{ fontSize:12, color:theme.muted, textAlign:"center" }}>{f.weight}%</span>
@@ -286,8 +305,8 @@ export default function {{COMPONENT_NAME}}() {
 
         {/* FOOTER */}
         <div style={{ marginTop:32,padding:"14px 0",borderTop:`1px solid ${theme.border}`,display:"flex",justifyContent:"space-between",fontSize:11,color:theme.muted }}>
-          <span>Clarion Intelligence Systems LLC -- Research only, not investment advice</span>
-          <span>Price: yfinance -- SEC: EDGAR ({{ACCESSION}}) -- {dataTs}</span>
+          <span>{{FOOTER_ATTRIBUTION}}</span>
+          <span>Research only, not investment advice · Price: yfinance -- SEC: EDGAR ({{ACCESSION}}) -- {dataTs}</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Ports the Zo Space thesis-page template improvements proven on the 13 live pages at cis.zo.space:

- Mobile: all grids collapse below 640px (metrics 3-col, scenarios/sizing/screener single-col, factor rows drop detail columns) — cards no longer overflow phone viewports
- `minmax(0,1fr)` grid columns to prevent content-driven overflow
- Newsreader/Inter/mono font stack constants on the theme object
- Branding is now placeholders (`{{BRAND_NAME}}`, `{{BRAND_URL}}`, `{{FOOTER_ATTRIBUTION}}`) so installs aren't hardcoded to any one firm's identity; placeholders documented in SKILL.md
- Deliberately NOT ported: `[data-zo-built-on-badge]` hiding (user-specific choice, wrong as a public default)

Suite: 793 passed (no code paths touched — template assets + docs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)