### PR TITLE
feat(monitor): LLM health scoring v2 via /zo/ask — carry-forward-safe

### DIFF
--- a/lib/ai_buffett_zo/theses/__init__.py
+++ b/lib/ai_buffett_zo/theses/__init__.py
@@ -42,6 +42,7 @@ from ai_buffett_zo.theses.types import (
     ThesisMetadata,
     ValuationScenario,
 )
+from ai_buffett_zo.theses.llm_scores import score_thesis_with_llm
 
 __all__ = [
     "Action",
@@ -72,6 +73,7 @@ __all__ = [
     "score_catalyst_proximity",
     "score_risk_environment",
     "score_valuation_safety",
+    "score_thesis_with_llm",
     "thesis_path",
     "update_health_table",
     "update_kill_conditions_last_checked",

--- a/lib/ai_buffett_zo/theses/llm_scores.py
+++ b/lib/ai_buffett_zo/theses/llm_scores.py
@@ -1,0 +1,276 @@
+"""LLM-driven health component scoring via /zo/ask.
+
+Three components can't be scored algorithmically from a few numbers — they
+need to read the thesis prose and reason over it:
+
+    Business Health   — revenue growth, margin trends, competitive position, balance sheet
+    Insider Alignment — insider transactions, compensation structure, share count trends
+    Thesis Integrity  — whether the core claims still hold, evidence remains valid,
+                         logic intact, kill conditions are still appropriate
+
+This module sends the full thesis markdown to a child Zo invocation via
+the /zo/ask API and extracts structured scores + notes from the response.
+
+Why /zo/ask instead of an LLM library call:
+    - Same model as the parent — no dependency drift.
+    - Inherits the workspace, file access, and persona rules.
+    - We want the agent's judgment, not raw model output — the agent
+      can cross-reference SEC filings, check yfinance, and spot
+      inconsistencies that raw text scoring would miss.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import Any
+
+from ai_buffett_zo.theses.types import HealthComponent
+
+_API = "https://api.zo.computer/zo/ask"
+
+# Model for the scoring call. Unset (default) omits model_name so the
+# child invocation uses the Zo account's default model. Override with
+# e.g. CLARION_LLM_SCORES_MODEL="zo:openai/gpt-5.4-mini" to pin a cheap
+# model for this high-frequency, low-difficulty scoring task.
+_MODEL_ENV = "CLARION_LLM_SCORES_MODEL"
+
+# Timeout for each /zo/ask invocation (seconds). 3 components in one call,
+# but the model needs to read a full thesis — generous timeout.
+_REQUEST_TIMEOUT = 120
+
+# Retries for transient failures.
+_MAX_RETRIES = 2
+_RETRY_DELAY_S = 5
+
+
+def score_thesis_with_llm(
+    *,
+    ticker: str,
+    thesis_markdown: str,
+    current_price: float | None,
+    base_case_fair_value: float | None,
+) -> dict[str, HealthComponent]:
+    """Score Business Health, Insider Alignment, and Thesis Integrity.
+
+    Returns a dict of successfully-scored HealthComponents, keyed by
+    display name. On failure (no token, network error, timeout, unparseable
+    response) the failed components are OMITTED — never zero-filled — so
+    the caller carries forward previous scores instead of cratering the
+    Overall score with fabricated zeros.
+
+    The prompt includes the full thesis markdown so the agent can reason
+    over claims, evidence citations, financial data, and kill conditions.
+    """
+    import sys
+
+    token = os.environ.get("ZO_CLIENT_IDENTITY_TOKEN")
+    if not token:
+        print(
+            "llm_scores: ZO_CLIENT_IDENTITY_TOKEN not set — carrying forward "
+            "previous LLM component scores",
+            file=sys.stderr,
+        )
+        return {}
+
+    prompt = _build_prompt(
+        ticker=ticker,
+        thesis_markdown=thesis_markdown,
+        current_price=current_price,
+        base_case_fair_value=base_case_fair_value,
+    )
+
+    for attempt in range(1 + _MAX_RETRIES):
+        try:
+            result = _call_zo_ask(prompt, token=token)
+            return _parse_scores(result, ticker=ticker)
+        except Exception as e:
+            print(
+                f"llm_scores: {ticker} attempt {attempt + 1}/{1 + _MAX_RETRIES} "
+                f"failed: {type(e).__name__}: {e}",
+                file=sys.stderr,
+            )
+            if attempt < _MAX_RETRIES:
+                time.sleep(_RETRY_DELAY_S)
+            continue
+
+    print(
+        f"llm_scores: {ticker} scoring failed after {1 + _MAX_RETRIES} attempts — "
+        "carrying forward previous LLM component scores",
+        file=sys.stderr,
+    )
+    return {}
+
+
+def _build_prompt(
+    *,
+    ticker: str,
+    thesis_markdown: str,
+    current_price: float | None,
+    base_case_fair_value: float | None,
+) -> str:
+    price_str = f"${current_price:.2f}" if current_price is not None else "unknown"
+    fv_str = f"${base_case_fair_value:.2f}" if base_case_fair_value is not None else "unknown"
+
+    return f"""You are scoring an investment thesis for {ticker}. Current price: {price_str}. Base case fair value: {fv_str}.
+
+Read the full thesis below and score THREE dimensions. Return ONLY valid JSON — no markdown, no commentary before or after.
+
+Scoring rubric for each dimension (0-100):
+
+**Business Health** (weight 20%): Assess revenue growth trajectory, margin trends (gross and operating), competitive position durability, balance sheet strength. A healthy business grows revenue, maintains or expands margins, and has a manageable debt load.
+- 90-100: Accelerating revenue, expanding margins, fortress balance sheet
+- 70-89: Steady growth, stable margins, conservative leverage
+- 50-69: Decelerating growth, margin pressure, above-average leverage
+- 30-49: Stalling revenue, declining margins, concerning leverage
+- 0-29: Revenue shrinking, margin collapse, distressed balance sheet
+
+**Insider Alignment** (weight 10%): Assess insider buying/selling patterns (if mentioned), compensation structure alignment with shareholders, share count changes over time (buybacks or dilution). Insider buying is bullish; heavy selling without stated reason is bearish; aggressive buybacks that reduce share count are a positive signal.
+- 90-100: Heavy insider buying, rational compensation, aggressive buybacks reducing share count
+- 70-89: Moderate insider buying or strong buybacks, compensation aligned
+- 50-69: Neutral — no concerning signals but nothing notably positive
+- 30-49: Insider selling (non-diversification), dilutive comp, share count growing
+- 0-29: Heavy insider selling, egregious comp, massive dilution
+
+**Thesis Integrity** (weight 25%): Assess whether the core claims in "What I Believe" still hold, whether the evidence cited remains valid, whether the valuation assumptions are reasonable at the current price, and whether the kill conditions are specific, measurable, and appropriate. A strong thesis has falsifiable claims, current evidence, and kill conditions that are binary triggers.
+- 90-100: Core claims intact and strengthened, evidence current, kill conditions sharp and binary
+- 70-89: Core claims mostly hold, evidence reasonable, kill conditions adequate
+- 50-69: Some claims weakening or evidence going stale, kill conditions could be tighter
+- 30-49: Core thesis showing cracks, evidence outdated, kill conditions vague
+- 0-29: Thesis broken — claims contradicted by recent data, evidence invalidated
+
+For each dimension, include:
+- "score": integer 0-100
+- "notes": 1-2 sentence explanation with specific observations from the thesis text
+
+Return this exact JSON structure:
+{{
+  "business_health": {{ "score": 0, "notes": "..." }},
+  "insider_alignment": {{ "score": 0, "notes": "..." }},
+  "thesis_integrity": {{ "score": 0, "notes": "..." }}
+}}
+
+THESIS TO EVALUATE:
+---
+{thesis_markdown}
+---
+"""
+
+
+def _call_zo_ask(prompt: str, *, token: str) -> str:
+    """Post to /zo/ask and return the raw text output.
+
+    The child Zo returns its response as text in the "output" field.
+    The caller strips any markdown fences and parses JSON from it.
+    """
+    import urllib.request
+
+    payload: dict[str, Any] = {"input": prompt}
+    model = os.environ.get(_MODEL_ENV, "").strip()
+    if model:
+        payload["model_name"] = model
+    body = json.dumps(payload).encode("utf-8")
+
+    req = urllib.request.Request(
+        _API,
+        data=body,
+        headers={
+            "authorization": token,
+            "content-type": "application/json",
+        },
+        method="POST",
+    )
+
+    with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT) as resp:
+        data = json.loads(resp.read().decode("utf-8"))
+
+    output = data.get("output", "")
+    if not isinstance(output, str):
+        raise ValueError(f"Unexpected /zo/ask output type: {type(output)}")
+
+    return output
+
+
+def _parse_scores(
+    raw: str,
+    *,
+    ticker: str,
+) -> dict[str, HealthComponent]:
+    """Extract the three component scores from the LLM response.
+
+    Handles responses wrapped in ```json fences, bare JSON, or markdown
+    that contains an embedded JSON object. Components that are missing
+    or malformed are omitted from the result (carried forward by the
+    caller) — never zero-filled.
+    """
+    json_str = raw.strip()
+
+    # Strip ```json / ``` fences if present.
+    if json_str.startswith("```"):
+        json_str = json_str.split("\n", 1)[-1] if "\n" in json_str else ""
+        if json_str.endswith("```"):
+            json_str = json_str[:-3].strip()
+
+    try:
+        parsed = json.loads(json_str)
+    except json.JSONDecodeError:
+        # Try to find a JSON object in the response.
+        import re
+        match = re.search(r'\{.*"business_health".*\}', raw, re.DOTALL)
+        if not match:
+            return {}
+        try:
+            parsed = json.loads(match.group(0))
+        except json.JSONDecodeError:
+            return {}
+
+    if not isinstance(parsed, dict):
+        return {}
+
+    out: dict[str, HealthComponent] = {}
+    for json_key, display_name in (
+        ("business_health", "Business Health"),
+        ("insider_alignment", "Insider Alignment"),
+        ("thesis_integrity", "Thesis Integrity"),
+    ):
+        hc = _extract_component(parsed, json_key, display_name, ticker)
+        if hc is not None:
+            out[display_name] = hc
+    return out
+
+
+def _extract_component(
+    data: dict,
+    json_key: str,
+    display_name: str,
+    ticker: str,
+) -> HealthComponent | None:
+    inner = data.get(json_key)
+    if not isinstance(inner, dict) or not isinstance(inner.get("score"), (int, float)):
+        return None
+
+    score = _clamp_score(inner.get("score"))
+    notes = str(inner.get("notes", "")).strip()
+    if not notes:
+        notes = f"{display_name} scored {score}/100 by LLM for {ticker}"
+
+    return HealthComponent(
+        name=display_name,
+        weight=_DEFAULT_WEIGHTS.get(display_name, 0),
+        score=score,
+        notes=notes,
+    )
+
+
+_DEFAULT_WEIGHTS = {
+    "Business Health": 20,
+    "Insider Alignment": 10,
+    "Thesis Integrity": 25,
+}
+
+
+def _clamp_score(value: object) -> int:
+    if isinstance(value, (int, float)):
+        return max(0, min(100, int(value)))
+    return 0

--- a/skills/clarion-thesis-monitor/SKILL.md
+++ b/skills/clarion-thesis-monitor/SKILL.md
@@ -62,16 +62,20 @@ Cadence guidance:
 
 ## What gets recomputed
 
-| Component | v1 behavior | Notes |
+| Component | Behavior | Notes |
 |---|---|---|
 | Valuation Safety | If `--current-price` provided AND a `base_case_fair_value` is in the thesis metadata, recomputed. Else carried forward. | Add `base_case_fair_value: 480.0` to the thesis metadata block to enable auto-scoring. |
-| Business Health | Carried forward in v1 | Future: `/zo/ask` over recent MD&A snippets |
-| Insider Alignment | Carried forward in v1 | Future: WebSearch over recent Form 4s |
+| Business Health | **v2: LLM-scored via `/zo/ask`** (full mode only) | Reads the whole thesis; scores growth, margins, competitive position, balance sheet |
+| Insider Alignment | **v2: LLM-scored via `/zo/ask`** (full mode only) | Insider transactions, comp structure, share count trends |
 | Catalyst Proximity | If `catalyst_date` in metadata, recomputed. Else carried forward. | Add `catalyst_date: 2026-08-15` to enable auto-scoring. |
-| Thesis Integrity | Carried forward in v1 | Future: `/zo/ask` over thesis evidence + new filings |
+| Thesis Integrity | **v2: LLM-scored via `/zo/ask`** (full mode only) | Do the core claims still hold, is evidence current, are kill conditions sharp |
 | Risk Environment | **Always recomputed** | regime × bucket matrix |
 
-When the lib's deterministic-scoring v2 lands (LLM-driven Business Health / Thesis Integrity via `/zo/ask`), the carry-forward defaults will be replaced. The user's manually-set scores remain authoritative until then.
+LLM scoring (v2) details:
+
+- Requires `ZO_CLIENT_IDENTITY_TOKEN` in the environment (present on Zo). Without it — or on any network / parsing failure — the affected components are **carried forward from the previous run, never zero-filled**, and a warning is printed to stderr. The system refuses to fabricate health scores.
+- `--quick` mode never makes LLM calls — dailies stay fast and free.
+- One `/zo/ask` call per active thesis per full run. Set `CLARION_LLM_SCORES_MODEL` (e.g. `zo:openai/gpt-5.4-mini`) to pin a cheap model for this task; unset, the account's default model is used.
 
 ## How to run
 

--- a/skills/clarion-thesis-monitor/scripts/monitor.py
+++ b/skills/clarion-thesis-monitor/scripts/monitor.py
@@ -7,8 +7,7 @@ Risk Environment), checks kill condition statuses, aggregates to an Overall
 score, recommends an action, and writes the result back to each thesis file.
 
 LLM-driven components (Business Health, Insider Alignment, Thesis Integrity)
-are carried forward from the previous run in v1. v2 will integrate /zo/ask
-for those.
+are scored via /zo/ask by `ai_buffett_zo.theses.llm_scores` (v2 integration).
 
 Usage:
     python monitor.py                       # all active theses, full mode
@@ -48,6 +47,7 @@ from ai_buffett_zo.theses import (
     update_kill_conditions_last_checked,
     update_metadata_block,
 )
+from ai_buffett_zo.theses.llm_scores import score_thesis_with_llm
 from ai_buffett_zo.voice import footer, header, md_table
 
 
@@ -94,6 +94,7 @@ def _recompute_components(
     current_price: float | None,
     quick: bool,
     asof: date,
+    content: str,
 ) -> tuple[list[HealthComponent], list[str]]:
     """Recompute the directly-derivable components, carry forward the rest.
 
@@ -154,6 +155,30 @@ def _recompute_components(
             notes=f"catalyst {catalyst_date.isoformat()} ({days}d away)",
         )
 
+    # LLM-driven components — Business Health, Insider Alignment, Thesis Integrity.
+    # v2: call /zo/ask to score these. score_thesis_with_llm OMITS components it
+    # could not score (never zero-fills), so anything not returned here keeps its
+    # carried-forward score — per the "never fabricate health scores" rule.
+    try:
+        llm_scored = score_thesis_with_llm(
+            ticker=metadata.ticker,
+            thesis_markdown=content,
+            current_price=current_price,
+            base_case_fair_value=base_case,
+        )
+        for name, hc in llm_scored.items():
+            if name in by_name:
+                old_score = by_name[name].score
+                by_name[name] = hc
+                if old_score != hc.score and old_score != 0:
+                    notes.append(f"{name} {old_score}→{hc.score}")
+    except Exception as e:
+        print(
+            f"monitor: LLM scoring failed for {metadata.ticker} "
+            f"({type(e).__name__}: {e}) — carrying forward previous scores",
+            file=sys.stderr,
+        )
+
     return list(by_name.values()), notes
 
 
@@ -187,6 +212,7 @@ def _process_thesis(
         current_price=current_price,
         quick=quick,
         asof=asof,
+        content=content,
     )
 
     snap = evaluate(

--- a/tests/test_llm_scores.py
+++ b/tests/test_llm_scores.py
@@ -1,0 +1,198 @@
+"""Tests for ai_buffett_zo.theses.llm_scores.
+
+The real-money invariant under test: on ANY failure (no token, network
+error, unparseable response, missing component), failed components are
+OMITTED — never zero-filled — so the monitor carries forward previous
+scores instead of cratering the Overall score with fabricated zeros.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ai_buffett_zo.theses import llm_scores
+from ai_buffett_zo.theses.llm_scores import (
+    _parse_scores,
+    score_thesis_with_llm,
+)
+
+GOOD_RESPONSE = json.dumps(
+    {
+        "business_health": {"score": 82, "notes": "Revenue accelerating."},
+        "insider_alignment": {"score": 55, "notes": "Neutral Form 4 activity."},
+        "thesis_integrity": {"score": 74, "notes": "Claims hold; evidence current."},
+    }
+)
+
+
+def _score(**kwargs):
+    defaults = dict(
+        ticker="NVDA",
+        thesis_markdown="# Thesis\n\nBody.",
+        current_price=100.0,
+        base_case_fair_value=120.0,
+    )
+    defaults.update(kwargs)
+    return score_thesis_with_llm(**defaults)
+
+
+# ---- parsing ---------------------------------------------------------------
+
+
+def test_parse_bare_json():
+    out = _parse_scores(GOOD_RESPONSE, ticker="NVDA")
+    assert set(out) == {"Business Health", "Insider Alignment", "Thesis Integrity"}
+    assert out["Business Health"].score == 82
+    assert out["Business Health"].weight == 20
+    assert out["Insider Alignment"].score == 55
+    assert out["Thesis Integrity"].score == 74
+    assert "accelerating" in out["Business Health"].notes.lower()
+
+
+def test_parse_fenced_json():
+    fenced = f"```json\n{GOOD_RESPONSE}\n```"
+    out = _parse_scores(fenced, ticker="NVDA")
+    assert len(out) == 3
+    assert out["Thesis Integrity"].score == 74
+
+
+def test_parse_json_embedded_in_prose():
+    wrapped = f"Here are the scores you asked for:\n\n{GOOD_RESPONSE}\n\nLet me know."
+    out = _parse_scores(wrapped, ticker="NVDA")
+    assert len(out) == 3
+
+
+def test_parse_garbage_returns_empty():
+    assert _parse_scores("I could not score this thesis.", ticker="NVDA") == {}
+    assert _parse_scores("", ticker="NVDA") == {}
+    assert _parse_scores("[1, 2, 3]", ticker="NVDA") == {}
+
+
+def test_parse_missing_component_is_omitted_not_zeroed():
+    partial = json.dumps({"business_health": {"score": 60, "notes": "ok"}})
+    out = _parse_scores(partial, ticker="NVDA")
+    assert set(out) == {"Business Health"}
+    assert "Insider Alignment" not in out  # omitted → caller carries forward
+
+
+def test_parse_malformed_score_is_omitted():
+    bad = json.dumps(
+        {
+            "business_health": {"score": "high", "notes": "not numeric"},
+            "thesis_integrity": {"score": 70, "notes": "fine"},
+        }
+    )
+    out = _parse_scores(bad, ticker="NVDA")
+    assert "Business Health" not in out
+    assert out["Thesis Integrity"].score == 70
+
+
+def test_parse_clamps_out_of_range_scores():
+    wild = json.dumps(
+        {
+            "business_health": {"score": 150, "notes": "over"},
+            "insider_alignment": {"score": -5, "notes": "under"},
+            "thesis_integrity": {"score": 70.6, "notes": "float"},
+        }
+    )
+    out = _parse_scores(wild, ticker="NVDA")
+    assert out["Business Health"].score == 100
+    assert out["Insider Alignment"].score == 0
+    assert out["Thesis Integrity"].score == 70
+
+
+# ---- failure semantics -----------------------------------------------------
+
+
+def test_no_token_returns_empty(capsys):
+    # conftest strips ZO_CLIENT_IDENTITY_TOKEN for every test.
+    assert _score() == {}
+    assert "carrying forward" in capsys.readouterr().err
+
+
+def test_call_failure_returns_empty_after_retries(monkeypatch, capsys):
+    monkeypatch.setenv("ZO_CLIENT_IDENTITY_TOKEN", "fake-token")
+    calls = {"n": 0}
+
+    def boom(prompt, *, token):
+        calls["n"] += 1
+        raise OSError("network down")
+
+    monkeypatch.setattr(llm_scores, "_call_zo_ask", boom)
+    monkeypatch.setattr(llm_scores.time, "sleep", lambda s: None)
+
+    assert _score() == {}
+    assert calls["n"] == 1 + llm_scores._MAX_RETRIES
+    err = capsys.readouterr().err
+    assert "network down" in err
+    assert "carrying forward" in err
+
+
+def test_successful_call_returns_components(monkeypatch):
+    monkeypatch.setenv("ZO_CLIENT_IDENTITY_TOKEN", "fake-token")
+    monkeypatch.setattr(llm_scores, "_call_zo_ask", lambda prompt, *, token: GOOD_RESPONSE)
+    out = _score()
+    assert len(out) == 3
+    assert out["Business Health"].score == 82
+
+
+def test_model_env_omitted_by_default(monkeypatch):
+    """Without CLARION_LLM_SCORES_MODEL, the payload has no model_name."""
+    monkeypatch.setenv("ZO_CLIENT_IDENTITY_TOKEN", "fake-token")
+    monkeypatch.delenv("CLARION_LLM_SCORES_MODEL", raising=False)
+    captured = {}
+
+    class FakeResp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self):
+            return json.dumps({"output": GOOD_RESPONSE}).encode()
+
+    def fake_urlopen(req, timeout=None):
+        captured["body"] = json.loads(req.data.decode())
+        captured["auth"] = req.headers.get("Authorization")
+        return FakeResp()
+
+    import urllib.request
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    out = _score()
+    assert len(out) == 3
+    assert "model_name" not in captured["body"]
+    assert captured["auth"] == "fake-token"
+
+    monkeypatch.setenv("CLARION_LLM_SCORES_MODEL", "zo:openai/gpt-5.4-mini")
+    _score()
+    assert captured["body"]["model_name"] == "zo:openai/gpt-5.4-mini"
+
+
+# ---- prompt construction ---------------------------------------------------
+
+
+def test_prompt_includes_thesis_and_prices():
+    p = llm_scores._build_prompt(
+        ticker="NVDA",
+        thesis_markdown="UNIQUE-THESIS-BODY",
+        current_price=101.5,
+        base_case_fair_value=120.0,
+    )
+    assert "UNIQUE-THESIS-BODY" in p
+    assert "$101.50" in p
+    assert "$120.00" in p
+    assert "business_health" in p
+
+
+def test_prompt_handles_missing_prices():
+    p = llm_scores._build_prompt(
+        ticker="NVDA",
+        thesis_markdown="body",
+        current_price=None,
+        base_case_fair_value=None,
+    )
+    assert "unknown" in p

--- a/tests/test_thesis_monitor_skill.py
+++ b/tests/test_thesis_monitor_skill.py
@@ -384,3 +384,46 @@ def test_health_components_in_template_match_canonical(monitor_mod) -> None:
     from ai_buffett_zo.theses.types import HEALTH_COMPONENT_NAMES as canonical
 
     assert canonical == HEALTH_COMPONENT_NAMES
+
+
+# ---- LLM scoring integration (v2) ------------------------------------------
+
+
+def test_llm_scores_update_components_when_available(
+    monitor_mod, troot: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """When score_thesis_with_llm returns components, they replace the
+    carried-forward scores and the change is noted."""
+    from ai_buffett_zo.theses import HealthComponent
+
+    path = _write_thesis(troot, "NVDA", SAMPLE_THESIS)
+    _patch(monitor_mod, monkeypatch, current_price=440.0)
+    monkeypatch.setattr(
+        monitor_mod,
+        "score_thesis_with_llm",
+        lambda **kw: {
+            "Business Health": HealthComponent(
+                name="Business Health", weight=20, score=40, notes="margins compressing"
+            )
+        },
+    )
+
+    rc = monitor_mod.run(_args())
+    assert rc == 0
+    md = path.read_text()
+    assert "margins compressing" in md
+
+
+def test_llm_failure_carries_forward_previous_scores(
+    monitor_mod, troot: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The real-money invariant: empty LLM result must NOT zero out the
+    previously-scored components (Business Health stays 90 from the file)."""
+    path = _write_thesis(troot, "NVDA", SAMPLE_THESIS)
+    _patch(monitor_mod, monkeypatch, current_price=440.0)
+    monkeypatch.setattr(monitor_mod, "score_thesis_with_llm", lambda **kw: {})
+
+    rc = monitor_mod.run(_args())
+    assert rc == 0
+    md = path.read_text()
+    assert "| Business Health | 20% | 90 |" in md


### PR DESCRIPTION
Completes the v2 integration that was WIP on the Zo workspace: Business Health, Insider Alignment, and Thesis Integrity are now scored by an LLM reading the full thesis (full mode only), replacing v1 carry-forward.

QA hardening applied to the original WIP before shipping:

- **Real-money safety fix**: the WIP returned zero-valued components on LLM failure, and the monitor overwrote carried-forward scores with those zeros — cratering Overall and risking false REDUCE/EXIT verdicts. Failure now OMITS components so previous scores carry forward ("never fabricate health scores").
- Hardcoded `vercel:deepseek/deepseek-v4-pro` model pin replaced by `CLARION_LLM_SCORES_MODEL` env (default: account's default model) — the pin contradicted the module's own "same model as the parent" rationale and wouldn't exist for other installs.
- Silent `except: pass` paths now log to stderr (same principle as the #64 summary-failure logging fix).
- `--quick` never calls the LLM; one /zo/ask call per active thesis per full run, documented in SKILL.md.
- 15 new tests incl. the monitor-level carry-forward invariant. Existing conftest already strips ambient Zo tokens, so the suite stays hermetic.

Suite: 801 passed. Secret scan: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)