### PR TITLE
fix(setup): pin uv install to running interpreter + Python >=3.12 guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Personas and routing rules are **not** modified by `clarion-setup` re-runs — t
 
 ## Skills
 
-All 10 skills ship together. Install whichever you need:
+All 11 skills ship together. Install whichever you need:
 
 | Skill | What it does |
 |---|---|
@@ -121,6 +121,9 @@ All 10 skills ship together. Install whichever you need:
 | `clarion-thesis-monitor` | Health-checks every active thesis: refresh prices, check kill conditions, recommend EXIT / REDUCE / HOLD / ADD. |
 | `clarion-watchlist-update` | Refreshes the latest watchlist with current prices and flags what's moved or hit triggers. |
 | `clarion-living-letter-update` | Updates the annual investor letter with a new quarterly entry. |
+| `clarion-portfolio-monitor` | Fetches live TastyTrade balances/positions/P&L, plus a FIFO trade ledger for auditable cost basis. Requires TastyTrade OAuth secrets. |
+
+Three additional tactical skills (`clarion-tactical-overlay`, `clarion-stock-signals`, `clarion-fomc-intel`) wrap the strategy engines in a separate research repo that is not yet public; they are not shipped here. If that repo opens up, they'll be added.
 
 ## Requirements
 

--- a/skills/clarion-setup/scripts/setup.py
+++ b/skills/clarion-setup/scripts/setup.py
@@ -171,7 +171,10 @@ def install_library(lib_dir: Path) -> tuple[int, str, str]:
     in_venv = bool(os.environ.get("VIRTUAL_ENV"))
     cmd = ["uv", "pip", "install", "--quiet", "-e", str(lib_dir)]
     if not in_venv:
-        cmd.insert(3, "--system")
+        # Pin to the interpreter running this script — uv's default "system"
+        # python may be an older OS python (e.g. Debian's 3.11) that cannot
+        # satisfy the library's >=3.12 requirement.
+        cmd[3:3] = ["--system", "--python", sys.executable]
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     return result.returncode, result.stdout, result.stderr
 
@@ -231,6 +234,13 @@ def main() -> None:
     args = parser.parse_args()
 
     print("Clarion Intelligence System — setup\n")
+
+    if sys.version_info < (3, 12):
+        fail(
+            f"Python >= 3.12 required, running under {sys.version.split()[0]}. "
+            "Re-run with a newer interpreter (e.g. python3.12 setup.py or "
+            "/usr/local/bin/python setup.py on Zo)."
+        )
 
     # Step 1 — uv on PATH
     if shutil.which("uv") is None:


### PR DESCRIPTION
Fresh-install simulation (clean public clone → `setup.py --skip-skills` with a clean `CLARION_DATA_ROOT`) caught a real new-user blocker: `uv pip install --system` targets the OS default python (3.11 on Debian 12), which can't satisfy the library's `>=3.12` — install died at step 1.

- `install_library` now passes `--python sys.executable` so the library lands in the interpreter actually running setup
- Early guard fails fast under <3.12 with an actionable message (verified under python3.11: clean error, no partial install)
- Post-fix fresh-install sim: `SETUP_RESULT: ok`, full data tree created
- README: skill count corrected to 11, adds missing `clarion-portfolio-monitor` row, notes the three tactical skills that live in a separate non-public repo

Suite: 808 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)