### PR TITLE
feat(monitor): llm_scores model resolves env > clarion config > account default

### DIFF
--- a/lib/ai_buffett_zo/theses/llm_scores.py
+++ b/lib/ai_buffett_zo/theses/llm_scores.py
@@ -30,11 +30,31 @@ from ai_buffett_zo.theses.types import HealthComponent
 
 _API = "https://api.zo.computer/zo/ask"
 
-# Model for the scoring call. Unset (default) omits model_name so the
-# child invocation uses the Zo account's default model. Override with
-# e.g. CLARION_LLM_SCORES_MODEL="zo:openai/gpt-5.4-mini" to pin a cheap
-# model for this high-frequency, low-difficulty scoring task.
+# Model for the scoring call, resolved in order:
+#   1. CLARION_LLM_SCORES_MODEL env var
+#   2. "llm_scores_model" in ~/clarion/config.json
+#   3. unset — omit model_name so the child invocation uses the Zo
+#      account's default model
+# Pin a cheap model for this high-frequency, low-difficulty scoring task.
 _MODEL_ENV = "CLARION_LLM_SCORES_MODEL"
+_MODEL_CONFIG_KEY = "llm_scores_model"
+
+
+def _resolve_model() -> str:
+    env = os.environ.get(_MODEL_ENV, "").strip()
+    if env:
+        return env
+    try:
+        from ai_buffett_zo._paths import clarion_home
+
+        cfg_path = clarion_home() / "config.json"
+        if cfg_path.exists():
+            value = json.loads(cfg_path.read_text()).get(_MODEL_CONFIG_KEY, "")
+            if isinstance(value, str):
+                return value.strip()
+    except Exception:
+        pass
+    return ""
 
 # Timeout for each /zo/ask invocation (seconds). 3 components in one call,
 # but the model needs to read a full thesis — generous timeout.
@@ -167,7 +187,7 @@ def _call_zo_ask(prompt: str, *, token: str) -> str:
     import urllib.request
 
     payload: dict[str, Any] = {"input": prompt}
-    model = os.environ.get(_MODEL_ENV, "").strip()
+    model = _resolve_model()
     if model:
         payload["model_name"] = model
     body = json.dumps(payload).encode("utf-8")

--- a/tests/test_llm_scores.py
+++ b/tests/test_llm_scores.py
@@ -138,10 +138,13 @@ def test_successful_call_returns_components(monkeypatch):
     assert out["Business Health"].score == 82
 
 
-def test_model_env_omitted_by_default(monkeypatch):
-    """Without CLARION_LLM_SCORES_MODEL, the payload has no model_name."""
+def test_model_env_omitted_by_default(monkeypatch, tmp_path):
+    """Without CLARION_LLM_SCORES_MODEL or a config entry, no model_name."""
+    from ai_buffett_zo import _paths
+
     monkeypatch.setenv("ZO_CLIENT_IDENTITY_TOKEN", "fake-token")
     monkeypatch.delenv("CLARION_LLM_SCORES_MODEL", raising=False)
+    monkeypatch.setattr(_paths, "clarion_home", lambda: tmp_path)  # isolate from real config
     captured = {}
 
     class FakeResp:
@@ -196,3 +199,28 @@ def test_prompt_handles_missing_prices():
         base_case_fair_value=None,
     )
     assert "unknown" in p
+
+
+# ---- model resolution ------------------------------------------------------
+
+
+def test_model_resolution_env_beats_config(monkeypatch, tmp_path):
+    from ai_buffett_zo import _paths
+
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"llm_scores_model": "byok:from-config"}))
+    monkeypatch.setattr(_paths, "clarion_home", lambda: tmp_path)
+
+    monkeypatch.setenv("CLARION_LLM_SCORES_MODEL", "byok:from-env")
+    assert llm_scores._resolve_model() == "byok:from-env"
+
+    monkeypatch.delenv("CLARION_LLM_SCORES_MODEL", raising=False)
+    assert llm_scores._resolve_model() == "byok:from-config"
+
+
+def test_model_resolution_empty_without_env_or_config(monkeypatch, tmp_path):
+    from ai_buffett_zo import _paths
+
+    monkeypatch.delenv("CLARION_LLM_SCORES_MODEL", raising=False)
+    monkeypatch.setattr(_paths, "clarion_home", lambda: tmp_path)  # no config.json
+    assert llm_scores._resolve_model() == ""


### PR DESCRIPTION
Follow-up to #67: the scoring model is now configurable via `llm_scores_model` in `~/clarion/config.json` (same mechanism as `indexing_model`/`reasoning_model`), with the env var still taking precedence. Without a persistent env var, installs previously fell back to the account default model — which may be a metered model the user didn't intend for automated scoring.

3 new tests. Suite: 811 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)