### PR TITLE
chore(portfolio-monitor): registry metadata frontmatter

### DIFF
--- a/skills/clarion-portfolio-monitor/SKILL.md
+++ b/skills/clarion-portfolio-monitor/SKILL.md
@@ -4,6 +4,9 @@ description: Fetch live portfolio positions, balances, and daily transactions fr
 compatibility: Created for Zo Computer
 metadata:
   author: cis.zo.computer
+  category: External
+  display-name: Clarion Portfolio Monitor
+  homepage: https://github.com/jingerzz/clarion-intelligence-system
 ---
 
 # Clarion Portfolio Monitor


### PR DESCRIPTION
Adds category/display-name/homepage metadata matching the other ten skills, so the zocomputer/skills registry sync (PR zocomputer/skills#115) preserves presentation metadata on future refreshes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)