### PR TITLE
fix(secrag): cache ticker map, throttle SEC requests, back off on 429

### DIFF
--- a/lib/ai_buffett_zo/secrag/loader.py
+++ b/lib/ai_buffett_zo/secrag/loader.py
@@ -12,11 +12,16 @@ from __future__ import annotations
 import json
 import os
 import re
+import threading
+import time
 import urllib.error
 import urllib.request
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from datetime import date, timedelta
+from pathlib import Path
+
+from ai_buffett_zo._paths import clarion_home
 
 DEFAULT_USER_AGENT = "Clarion Intelligence System (clarion@example.com)"
 TICKERS_URL = "https://www.sec.gov/files/company_tickers.json"
@@ -27,6 +32,139 @@ ARCHIVE_URL = "https://www.sec.gov/Archives/edgar/data/{cik_int}/{accession_noda
 # pointer-only Items 7/8 (issue #26) reads this to find the R-file containing
 # the actual Consolidated Income Statement / Balance Sheet / Cash Flows.
 FILING_SUMMARY_URL = "https://www.sec.gov/Archives/edgar/data/{cik_int}/{accession_nodash}/FilingSummary.xml"
+
+# --- SEC fair-access controls (2026-07 backfill postmortem) ------------------
+#
+# SEC EDGAR's fair-access limit is 10 req/s; exceeding it triggers an HTTP 429
+# and a ~10-minute IP block. The 2026-05→07 backfill lost 3,568 jobs to a
+# cascade: every job re-downloaded the full ticker map (no cache) with no
+# throttle, and a 429 failed the job instantly while the loop hammered the
+# next one. Three controls fix that:
+#
+#   1. `_ticker_map` — the ticker→CIK map is one static ~1MB file; cache it
+#      in memory + on disk (default TTL 24h) instead of per-job downloads.
+#   2. `_throttle` — a global inter-request gap across ALL SEC calls in this
+#      process (default 8 req/s, safely under SEC's 10).
+#   3. `_open_with_retry` — 429/503 get exponential backoff (10s → capped
+#      600s, honoring Retry-After) instead of failing the job. The final
+#      attempt's error still propagates so the queue records real failures.
+#
+# Env overrides: SEC_MAX_RPS, SEC_RETRY_ATTEMPTS, SEC_TICKER_CACHE_TTL
+# (seconds; <=0 disables caching entirely — tests use this), SEC_TICKER_CACHE_PATH.
+
+_DEFAULT_MAX_RPS = 8.0
+_DEFAULT_RETRY_ATTEMPTS = 6
+_DEFAULT_TICKER_CACHE_TTL = 24 * 3600.0
+_RETRYABLE_HTTP_CODES = frozenset({429, 503})
+_MAX_BACKOFF_SECONDS = 600.0
+
+_rate_lock = threading.Lock()
+_last_request_at = 0.0
+
+_ticker_map_lock = threading.Lock()
+_ticker_map_mem: tuple[float, dict] | None = None
+
+
+def _ticker_cache_path() -> Path:
+    override = os.environ.get("SEC_TICKER_CACHE_PATH")
+    if override:
+        return Path(override)
+    return clarion_home() / "sec" / ".cache" / "company_tickers.json"
+
+
+def _ticker_cache_ttl() -> float:
+    try:
+        return float(os.environ.get("SEC_TICKER_CACHE_TTL", _DEFAULT_TICKER_CACHE_TTL))
+    except ValueError:
+        return _DEFAULT_TICKER_CACHE_TTL
+
+
+def _ticker_map(*, user_agent: str) -> dict:
+    """The SEC ticker→CIK map, cached in memory and on disk.
+
+    TTL <= 0 disables both cache layers (used by tests, which monkeypatch
+    `_get_json` and need each call to hit their fake).
+    """
+    global _ticker_map_mem
+    ttl = _ticker_cache_ttl()
+    if ttl <= 0:
+        return _get_json(TICKERS_URL, user_agent=user_agent)
+
+    now = time.time()
+    with _ticker_map_lock:
+        if _ticker_map_mem is not None and now - _ticker_map_mem[0] < ttl:
+            return _ticker_map_mem[1]
+
+        path = _ticker_cache_path()
+        try:
+            if path.exists() and now - path.stat().st_mtime < ttl:
+                data = json.loads(path.read_text())
+                _ticker_map_mem = (now, data)
+                return data
+        except (OSError, json.JSONDecodeError):
+            pass  # unreadable cache → refetch below
+
+        data = _get_json(TICKERS_URL, user_agent=user_agent)
+        _ticker_map_mem = (now, data)
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = path.with_suffix(".tmp")
+            tmp.write_text(json.dumps(data))
+            tmp.replace(path)
+        except OSError:
+            pass  # disk cache is best-effort; memory cache still holds
+        return data
+
+
+def _throttle() -> None:
+    """Enforce a minimum gap between SEC requests, globally for this process."""
+    global _last_request_at
+    try:
+        rps = float(os.environ.get("SEC_MAX_RPS", _DEFAULT_MAX_RPS))
+    except ValueError:
+        rps = _DEFAULT_MAX_RPS
+    if rps <= 0:
+        return
+    min_interval = 1.0 / rps
+    with _rate_lock:
+        now = time.monotonic()
+        wait = _last_request_at + min_interval - now
+        if wait > 0:
+            time.sleep(wait)
+        _last_request_at = time.monotonic()
+
+
+def _retry_attempts() -> int:
+    try:
+        return max(1, int(os.environ.get("SEC_RETRY_ATTEMPTS", _DEFAULT_RETRY_ATTEMPTS)))
+    except ValueError:
+        return _DEFAULT_RETRY_ATTEMPTS
+
+
+def _open_with_retry(req: urllib.request.Request, *, timeout: int):
+    """urlopen with global throttle + exponential backoff on 429/503.
+
+    Backoff schedule (attempt N retry delay): 10s, 30s, 90s, 270s, 600s —
+    long enough to outlast SEC's ~10-minute rate-limit block. Honors a
+    numeric Retry-After header when it asks for longer than our schedule.
+    """
+    attempts = _retry_attempts()
+    for attempt in range(attempts):
+        _throttle()
+        try:
+            return urllib.request.urlopen(req, timeout=timeout)
+        except urllib.error.HTTPError as e:
+            if e.code not in _RETRYABLE_HTTP_CODES or attempt == attempts - 1:
+                raise
+            delay = min(_MAX_BACKOFF_SECONDS, 10.0 * (3.0**attempt))
+            retry_after = e.headers.get("Retry-After") if e.headers else None
+            if retry_after:
+                try:
+                    delay = max(delay, float(retry_after))
+                except ValueError:
+                    pass
+            time.sleep(delay)
+    raise AssertionError("unreachable")  # loop always returns or raises
 
 
 class FilingNotFound(Exception):
@@ -182,7 +320,7 @@ def fetch_filing_by_accession(
 
 def _ticker_to_cik(ticker: str, *, user_agent: str) -> tuple[str, str]:
     """Resolve a ticker to (cik_padded, company_name) via SEC's tickers map."""
-    data = _get_json(TICKERS_URL, user_agent=user_agent)
+    data = _ticker_map(user_agent=user_agent)
     ticker_upper = ticker.upper()
     for entry in data.values():
         if entry.get("ticker", "").upper() == ticker_upper:
@@ -481,11 +619,11 @@ def _xml_int(elem: ET.Element, tag: str) -> int:
 
 def _get_json(url: str, *, user_agent: str, timeout: int = 30) -> dict:
     req = urllib.request.Request(url, headers={"User-Agent": user_agent, "Accept": "application/json"})
-    with urllib.request.urlopen(req, timeout=timeout) as resp:
+    with _open_with_retry(req, timeout=timeout) as resp:
         return json.loads(resp.read().decode("utf-8"))
 
 
 def _get_text(url: str, *, user_agent: str, timeout: int = 60) -> str:
     req = urllib.request.Request(url, headers={"User-Agent": user_agent})
-    with urllib.request.urlopen(req, timeout=timeout) as resp:
+    with _open_with_retry(req, timeout=timeout) as resp:
         return resp.read().decode("utf-8", errors="replace")

--- a/tests/test_secrag_loader.py
+++ b/tests/test_secrag_loader.py
@@ -13,6 +13,17 @@ from ai_buffett_zo.secrag import FilingNotFound, fetch_filing
 from ai_buffett_zo.secrag import loader
 
 
+@pytest.fixture(autouse=True)
+def _no_ticker_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disable the ticker-map cache so every test hits its own _get_json fake.
+
+    TTL <= 0 bypasses both the in-memory and on-disk cache layers; resetting
+    the memory slot guards against state leaking from a cache-enabled test.
+    """
+    monkeypatch.setenv("SEC_TICKER_CACHE_TTL", "0")
+    monkeypatch.setattr(loader, "_ticker_map_mem", None)
+
+
 _TICKERS_RESP = {
     "0": {"cik_str": 320193, "ticker": "AAPL", "title": "Apple Inc."},
     "1": {"cik_str": 1045810, "ticker": "NVDA", "title": "NVIDIA Corp"},
@@ -370,3 +381,104 @@ def test_fetch_filing_by_accession_strips_xslt_prefix(monkeypatch):
     )
     assert metadata.primary_doc == "wk-form4_1774386816.xml"
     assert "xslF345X06" not in metadata.primary_doc_url
+
+
+# --- SEC fair-access controls (2026-07 backfill postmortem) ------------------
+
+
+def test_ticker_map_cached_in_memory_and_on_disk(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """With a positive TTL, the ticker map is fetched once, then served from
+    cache — the fix for the backfill re-downloading it on every job."""
+    monkeypatch.setenv("SEC_TICKER_CACHE_TTL", "3600")
+    monkeypatch.setenv("SEC_TICKER_CACHE_PATH", str(tmp_path / "tickers.json"))
+    calls = {"n": 0}
+
+    def fake_get_json(url: str, *, user_agent: str, timeout: int = 30) -> dict:
+        assert "company_tickers" in url
+        calls["n"] += 1
+        return _TICKERS_RESP
+
+    monkeypatch.setattr(loader, "_get_json", fake_get_json)
+
+    assert loader._ticker_map(user_agent="ua")["1"]["ticker"] == "NVDA"
+    assert loader._ticker_map(user_agent="ua")["1"]["ticker"] == "NVDA"
+    assert calls["n"] == 1
+
+    # Fresh process (memory cache cleared) → served from disk, still no refetch.
+    monkeypatch.setattr(loader, "_ticker_map_mem", None)
+    assert loader._ticker_map(user_agent="ua")["0"]["ticker"] == "AAPL"
+    assert calls["n"] == 1
+
+
+def test_open_with_retry_backs_off_on_429(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 429 is retried with backoff instead of failing the job outright."""
+    import io
+    import urllib.error
+    import urllib.request
+
+    monkeypatch.setenv("SEC_MAX_RPS", "0")  # no throttle sleeps in tests
+    sleeps: list[float] = []
+    monkeypatch.setattr(loader.time, "sleep", sleeps.append)
+
+    attempts = {"n": 0}
+
+    def fake_urlopen(req, timeout=None):
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            raise urllib.error.HTTPError(
+                req.full_url, 429, "Too Many Requests", {}, io.BytesIO(b"")
+            )
+        return io.BytesIO(b"ok")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    req = urllib.request.Request("https://www.sec.gov/x")
+    resp = loader._open_with_retry(req, timeout=5)
+    assert resp.read() == b"ok"
+    assert attempts["n"] == 3
+    assert sleeps == [10.0, 30.0]
+
+
+def test_open_with_retry_gives_up_after_max_attempts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The final attempt's 429 propagates so the queue records a real failure."""
+    import io
+    import urllib.error
+    import urllib.request
+
+    monkeypatch.setenv("SEC_MAX_RPS", "0")
+    monkeypatch.setenv("SEC_RETRY_ATTEMPTS", "2")
+    monkeypatch.setattr(loader.time, "sleep", lambda _s: None)
+
+    def fake_urlopen(req, timeout=None):
+        raise urllib.error.HTTPError(
+            req.full_url, 429, "Too Many Requests", {}, io.BytesIO(b"")
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    req = urllib.request.Request("https://www.sec.gov/x")
+    with pytest.raises(urllib.error.HTTPError):
+        loader._open_with_retry(req, timeout=5)
+
+
+def test_open_with_retry_does_not_retry_404(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-retryable HTTP errors (e.g. 404 for pre-iXBRL FilingSummary) raise
+    immediately — callers depend on seeing them."""
+    import io
+    import urllib.error
+    import urllib.request
+
+    monkeypatch.setenv("SEC_MAX_RPS", "0")
+    attempts = {"n": 0}
+
+    def fake_urlopen(req, timeout=None):
+        attempts["n"] += 1
+        raise urllib.error.HTTPError(req.full_url, 404, "Not Found", {}, io.BytesIO(b""))
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    req = urllib.request.Request("https://www.sec.gov/x")
+    with pytest.raises(urllib.error.HTTPError):
+        loader._open_with_retry(req, timeout=5)
+    assert attempts["n"] == 1


### PR DESCRIPTION
## Problem
The 2026-05→07 SEC backfill lost **3,568 jobs** to SEC EDGAR HTTP 429 rate limiting (99.8% of all failures). Root cause in `secrag/loader.py`:
1. `_ticker_to_cik()` re-downloaded the full `company_tickers.json` (~1MB) on **every job** — each job cost ≥3 SEC requests.
2. No throttle and no 429 backoff: exceeding SEC's 10 req/s fair-access limit triggers a ~10-minute IP block, and while blocked the indexer failed each job instantly and hammered the next, cascading entire stretches of the queue into `.failed/`.

## Fix
- **`_ticker_map`** — memory + disk cache for the ticker→CIK map (default TTL 24h, atomic write; `SEC_TICKER_CACHE_TTL<=0` disables both layers, which tests use).
- **`_throttle`** — global inter-request gap across all SEC calls in the process, default 8 req/s (`SEC_MAX_RPS`).
- **`_open_with_retry`** — exponential backoff on 429/503: 10s→30s→90s→270s→600s (capped), honors `Retry-After`, `SEC_RETRY_ATTEMPTS` default 6. Final attempt's error still propagates so the queue records real failures. Non-retryable codes (e.g. 404 for pre-iXBRL FilingSummary) raise immediately as before.

Both HTTP seams (`_get_json`/`_get_text`) route through the wrapper, so submissions feeds, primary docs, FilingSummary.xml, and R-files are all covered. Tests monkeypatch the seams, so no throttle/retry sleeps leak into tests.

## Tests
- 4 new tests: cache hit (memory + disk), 429 backoff schedule, give-up-after-max-attempts, 404-not-retried
- Autouse fixture pins `SEC_TICKER_CACHE_TTL=0` for existing loader tests (isolation)
- Full suite: **814 passed**

## Follow-up (operational, not in this PR)
Re-enqueue the 3,568 retryable `.failed/` jobs (3,567×429 + 1 timeout); leave the 9 deterministic failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)