### PR TITLE
tune(llm): disable thinking on ollama structured calls (4.5x speedup)

### DIFF
--- a/lib/ai_buffett_zo/llm/zo_client.py
+++ b/lib/ai_buffett_zo/llm/zo_client.py
@@ -38,6 +38,10 @@ OLLAMA_PREFIX = "ollama:"
 OLLAMA_URL = os.environ.get("CLARION_OLLAMA_URL", "http://127.0.0.1:11434")
 OLLAMA_TIMEOUT = int(os.environ.get("CLARION_OLLAMA_TIMEOUT", "1800"))
 OLLAMA_KEEP_ALIVE = os.environ.get("CLARION_OLLAMA_KEEP_ALIVE", "60m")
+# Thinking-capable models (gemma4:26b/31b) emit hidden reasoning before the
+# constrained JSON — measured 4.5x slower for identical structured output.
+# Default off for indexing workloads; set CLARION_OLLAMA_THINK=1 to enable.
+OLLAMA_THINK = os.environ.get("CLARION_OLLAMA_THINK", "") in ("1", "true", "yes")
 OLLAMA_OPTIONS: dict[str, Any] = {
     "temperature": 0,
     "num_thread": int(os.environ.get("CLARION_OLLAMA_NUM_THREAD", "40")),
@@ -386,6 +390,7 @@ class ZoClient:
             "model": model_name[len(OLLAMA_PREFIX):],
             "messages": [{"role": "user", "content": input}],
             "stream": False,
+            "think": OLLAMA_THINK,
             "options": dict(OLLAMA_OPTIONS),
             "keep_alive": OLLAMA_KEEP_ALIVE,
         }


### PR DESCRIPTION
gemma4 thinking-capable models emit ~2-3k chars of hidden reasoning
before the format-constrained JSON: 58.2s vs 12.9s for an identical
section summary. think=false by default on the ollama route;
CLARION_OLLAMA_THINK=1 re-enables. e2b fallback accepts the flag.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
